### PR TITLE
Further improvemens to texture resolution.

### DIFF
--- a/src/RawModel.cpp
+++ b/src/RawModel.cpp
@@ -84,9 +84,9 @@ int RawModel::AddTriangle(const int v0, const int v1, const int v2, const int ma
     return (int) triangles.size() - 1;
 }
 
-int RawModel::AddTexture(const char *name, const char *fileName, const RawTextureUsage usage)
+int RawModel::AddTexture(const std::string &name, const std::string &fileName, const std::string &fileLocation, RawTextureUsage usage)
 {
-    if (name[0] == '\0') {
+    if (name.empty()) {
         return -1;
     }
     for (size_t i = 0; i < textures.size(); i++) {
@@ -95,17 +95,18 @@ int RawModel::AddTexture(const char *name, const char *fileName, const RawTextur
         }
     }
 
-    const ImageProperties properties = GetImageProperties(fileName);
+    const ImageProperties properties = GetImageProperties(!fileLocation.empty() ? fileLocation.c_str() : fileName.c_str());
 
     RawTexture texture;
-    texture.name      = name;
-    texture.width     = properties.width;
-    texture.height    = properties.height;
-    texture.mipLevels = (int) ceilf(Log2f(std::max((float) properties.width, (float) properties.height)));
-    texture.usage     = usage;
-    texture.occlusion = (properties.occlusion == IMAGE_TRANSPARENT) ?
-                        RAW_TEXTURE_OCCLUSION_TRANSPARENT : RAW_TEXTURE_OCCLUSION_OPAQUE;
-    texture.fileName  = fileName;
+    texture.name         = name;
+    texture.width        = properties.width;
+    texture.height       = properties.height;
+    texture.mipLevels    = (int) ceilf(Log2f(std::max((float) properties.width, (float) properties.height)));
+    texture.usage        = usage;
+    texture.occlusion    = (properties.occlusion == IMAGE_TRANSPARENT) ?
+                           RAW_TEXTURE_OCCLUSION_TRANSPARENT : RAW_TEXTURE_OCCLUSION_OPAQUE;
+    texture.fileName     = fileName;
+    texture.fileLocation = fileLocation;
     textures.emplace_back(texture);
     return (int) textures.size() - 1;
 }
@@ -312,9 +313,9 @@ void RawModel::Condense()
         for (auto &material : materials) {
             for (int j = 0; j < RAW_TEXTURE_USAGE_MAX; j++) {
                 if (material.textures[j] >= 0) {
-                    const RawTexture &texture     = oldTextures[material.textures[j]];
-                    const int        textureIndex = AddTexture(texture.name.c_str(), texture.fileName.c_str(), texture.usage);
-                    textures[textureIndex]   = texture;
+                    const RawTexture &texture = oldTextures[material.textures[j]];
+                    const int textureIndex = AddTexture(texture.name, texture.fileName, texture.fileLocation, texture.usage);
+                    textures[textureIndex] = texture;
                     material.textures[j] = textureIndex;
                 }
             }

--- a/src/RawModel.h
+++ b/src/RawModel.h
@@ -122,13 +122,14 @@ enum RawTextureOcclusion
 
 struct RawTexture
 {
-    std::string         name;
+    std::string         name;           // logical name in FBX file
     int                 width;
     int                 height;
     int                 mipLevels;
     RawTextureUsage     usage;
     RawTextureOcclusion occlusion;
-    std::string         fileName;
+    std::string         fileName;       // original filename in FBX file
+    std::string         fileLocation;   // inferred path in local filesystem, or ""
 };
 
 enum RawMaterialType
@@ -233,7 +234,7 @@ public:
     void AddVertexAttribute(const RawVertexAttribute attrib);
     int AddVertex(const RawVertex &vertex);
     int AddTriangle(const int v0, const int v1, const int v2, const int materialIndex, const int surfaceIndex);
-    int AddTexture(const char *name, const char *fileName, const RawTextureUsage usage);
+    int AddTexture(const std::string &name, const std::string &fileName, const std::string &fileLocation, RawTextureUsage usage);
     int AddMaterial(const RawMaterial &material);
     int AddMaterial(
         const char *name, const char *shadingModel, RawMaterialType materialType,

--- a/src/glTF/ImageData.cpp
+++ b/src/glTF/ImageData.cpp
@@ -31,8 +31,9 @@ ImageData::ImageData(std::string name, const BufferViewData &bufferView, std::st
 
 json ImageData::serialize() const
 {
-    if (mimeType.empty()) {
+    if (bufferView < 0) {
         return {
+            { "name", name },
             { "uri", uri }
         };
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -182,7 +182,7 @@ Copyright (c) 2016-2017 Oculus VR, LLC.
     if (verboseOutput) {
         fmt::printf("Loading FBX File: %s\n", inputPath);
     }
-    if (!LoadFBXFile(raw, inputPath.c_str(), "tga;bmp;png;jpg")) {
+    if (!LoadFBXFile(raw, inputPath.c_str(), "png;jpg;jpeg")) {
         fmt::fprintf(stderr, "ERROR:: Failed to parse FBX: %s\n", inputPath);
         return 1;
     }

--- a/src/utils/File_Utils.h
+++ b/src/utils/File_Utils.h
@@ -13,10 +13,10 @@
 namespace FileUtils {
     std::string GetCurrentFolder();
 
-    bool FolderExists(const char *folderPath);
+    bool FolderExists(const std::string &folderPath);
 
     bool MatchExtension(const char *fileExtension, const char *matchExtensions);
-    void ListFolderFiles(std::vector<std::string> &fileList, const char *folder, const char *matchExtensions);
+    std::vector<std::string> ListFolderFiles(const char *folder, const char *matchExtensions);
 
     bool CreatePath(const char *path);
 }

--- a/src/utils/Image_Utils.h
+++ b/src/utils/Image_Utils.h
@@ -10,6 +10,8 @@
 #ifndef __IMAGE_UTILS_H__
 #define __IMAGE_UTILS_H__
 
+#include <map>
+
 enum ImageOcclusion
 {
     IMAGE_OPAQUE,
@@ -25,5 +27,21 @@ struct ImageProperties
 };
 
 ImageProperties GetImageProperties(char const *filePath);
+
+/**
+ * Very simple method for mapping filename suffix to mime type. The glTF 2.0 spec only accepts values
+ * "image/jpeg" and "image/png" so we don't need to get too fancy.
+ */
+inline std::string suffixToMimeType(std::string suffix) {
+    std::transform(suffix.begin(), suffix.end(), suffix.begin(), ::tolower);
+
+    if (suffix == "jpg" || suffix == "jpeg") {
+        return "image/jpeg";
+    }
+    if (suffix == "png") {
+        return "image/png";
+    }
+    return "image/unknown";
+}
 
 #endif // !__IMAGE_UTILS_H__

--- a/src/utils/Image_Utils.h
+++ b/src/utils/Image_Utils.h
@@ -10,8 +10,6 @@
 #ifndef __IMAGE_UTILS_H__
 #define __IMAGE_UTILS_H__
 
-#include <map>
-
 enum ImageOcclusion
 {
     IMAGE_OPAQUE,

--- a/src/utils/String_Utils.h
+++ b/src/utils/String_Utils.h
@@ -73,6 +73,16 @@ namespace Gltf // TODO replace
             return fileName.substr(0, fileName.rfind('.')).c_str();
         }
 
+        inline const std::string GetFileSuffixString(const std::string &path)
+        {
+            const std::string fileName = GetFileNameString(path);
+            unsigned long pos          = fileName.rfind('.');
+            if (pos == std::string::npos) {
+                return "";
+            }
+            return fileName.substr(++pos);
+        }
+
         inline int CompareNoCase(const std::string &s1, const std::string &s2)
         {
             return strncasecmp(s1.c_str(), s2.c_str(), MAX_PATH_LENGTH);


### PR DESCRIPTION
- Move towards std::string over char * and FbxString where convenient,
- Make a clear distinction between textures whose image files have been
  located and those who haven't; warn early in the latter case.
- Extend RawTexture so we always know logical name in FBX, original file
  name in FBX, and inferred location in local filesystem.
- In non-binary mode, simply output the inferred local file basename as
  the URI; this will be the correct relative path as long as the texture
  files are located next to the .gltf and .bin files.

Primary remaining urge for a follow-up PR:

- We should be copying texture image files into the .gltf output folder,
  but before that we should switch to an off-the-shelf cross-platform
  file manipulation library like https://github.com/cginternals/cppfs.
  When we make that transition, all this texture resolution code will
  undergo another refactoring.