### PR TITLE
Copy texture files to output dir when appropriate.

### DIFF
--- a/src/Raw2Gltf.h
+++ b/src/Raw2Gltf.h
@@ -197,6 +197,7 @@ struct ModelData
 
 ModelData *Raw2Gltf(
     std::ofstream &gltfOutStream,
+    const std::string &outputFolder,
     const RawModel &raw,
     const GltfOptions &options
 );

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -172,6 +172,7 @@ Copyright (c) 2016-2017 Oculus VR, LLC.
     if (gltfOptions.outputBinary) {
         // in binary mode, we write precisely where we're asked
         modelPath = outputPath + ".glb";
+
     } else {
         // in gltf mode, we create a folder and write into that
         outputFolder = outputPath + "_out/";
@@ -206,7 +207,7 @@ Copyright (c) 2016-2017 Oculus VR, LLC.
         fmt::fprintf(stderr, "ERROR:: Couldn't open file for writing: %s\n", modelPath.c_str());
         return 1;
     }
-    data_render_model = Raw2Gltf(outStream, raw, gltfOptions);
+    data_render_model = Raw2Gltf(outStream, outputFolder, raw, gltfOptions);
 
     if (gltfOptions.outputBinary) {
         fmt::printf(

--- a/src/utils/File_Utils.cpp
+++ b/src/utils/File_Utils.cpp
@@ -9,6 +9,7 @@
 
 #include <string>
 #include <vector>
+#include <fstream>
 
 #include <stdint.h>
 #include <stdio.h>
@@ -173,5 +174,30 @@ namespace FileUtils {
             build[i] = clean[i];
         }
         return true;
+    }
+
+    bool CopyFile(const std::string &srcFilename, const std::string &dstFilename) {
+        std::ifstream srcFile(srcFilename, std::ios::binary);
+        if (!srcFile) {
+            fmt::printf("Warning: Couldn't open file %s for reading.\n", srcFilename);
+            return false;
+        }
+        // find source file length
+        srcFile.seekg(0, std::ios::end);
+        std::streamsize srcSize = srcFile.tellg();
+        srcFile.seekg(0, std::ios::beg);
+
+        std::ofstream dstFile(dstFilename, std::ios::binary | std::ios::trunc);
+        if (!dstFile) {
+            fmt::printf("Warning: Couldn't open file %s for writing.\n", srcFilename);
+            return false;
+        }
+        dstFile << srcFile.rdbuf();
+        std::streamsize dstSize = dstFile.tellp();
+        if (srcSize == dstSize) {
+            return true;
+        }
+        fmt::printf("Warning: Only copied %lu bytes to %s, when %s is %lu bytes long.\n", dstSize, dstFilename, srcFilename, srcSize);
+        return false;
     }
 }

--- a/src/utils/File_Utils.h
+++ b/src/utils/File_Utils.h
@@ -19,6 +19,8 @@ namespace FileUtils {
     std::vector<std::string> ListFolderFiles(const char *folder, const char *matchExtensions);
 
     bool CreatePath(const char *path);
+
+    bool CopyFile(const std::string &srcFilename, const std::string &dstFilename);
 }
 
 #endif // !__FILE_UTILS_H__


### PR DESCRIPTION
When we've successfully located a referenced texture image on the local filesystem and we're generating non-binary, non-embedded output, copy the source texture wholesale into the destination directory.

This means the output folder is always a full, free-standing deployment, one that can be dragged into e.g. https://gltf-viewer.donmccurdy.com/

This is surely far from the quickest way to copy a file, but it's effortlessly cross-platform and whether the process takes 10 or 20 milliseconds seems mostly irrelevant for a command line tool. This is really all just placeholder for C++17 and #include <filesystem> anyway.
