### PR TITLE
Fix and improve inheritance warnings.

### DIFF
--- a/src/Fbx2Raw.cpp
+++ b/src/Fbx2Raw.cpp
@@ -797,11 +797,11 @@ static void ReadNodeHierarchy(
         fmt::printf("node %d: %s\n", nodeIndex, newPath.c_str());
     }
 
-    static int warnRSrsCount = 0;
+    static int warnRrSsCount = 0;
     static int warnRrsCount  = 0;
-    if (lInheritType == FbxTransform::eInheritRSrs) {
-        if (++warnRSrsCount == 1) {
-            fmt::printf("Warning: node %s uses unsupported transform inheritance type 'eInheritRSrs'.\n", newPath);
+    if (lInheritType == FbxTransform::eInheritRrSs && !parentName.empty()) {
+        if (++warnRrSsCount == 1) {
+            fmt::printf("Warning: node %s uses unsupported transform inheritance type 'eInheritRrSs'.\n", newPath);
             fmt::printf("         (Further warnings of this type squelched.)\n");
         }
 


### PR DESCRIPTION
We were warnings against `eInheritRSrs`, which is actually the one type of inheritance we're good with. It's eInheritRrSs we should freak out about.

That said, no need to do it for the root node -- at that point there is no global transform to worry about.

Partially fixes https://github.com/facebookincubator/FBX2glTF/issues/27.