### PR TITLE
Support for Stingray PBS material definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,16 @@ ExternalProject_Add(Json
 )
 set(JSON_INCLUDE_DIR "${CMAKE_BINARY_DIR}/json/src/Json/src")
 
+# stb
+ExternalProject_Add(STB
+  PREFIX stb
+  GIT_REPOSITORY https://github.com/nothings/stb
+  CONFIGURE_COMMAND ${CMAKE_COMMAND} -E echo "Skipping STB configure step."
+  BUILD_COMMAND ${CMAKE_COMMAND} -E echo "Skipping STB build step."
+  INSTALL_COMMAND ${CMAKE_COMMAND} -E echo "Skipping STB install step."
+)
+set(STB_INCLUDE_DIR "${CMAKE_BINARY_DIR}/stb/src/STB")
+
 # cppcodec
 ExternalProject_Add(CPPCodec
   PREFIX cppcodec
@@ -150,6 +160,7 @@ add_dependencies(FBX2glTF
   MathFu
   FiFoMap
   Json
+  STB
   CxxOpts
   CPPCodec
   Fmt
@@ -181,6 +192,7 @@ target_include_directories(FBX2glTF PUBLIC
   ${FIFO_MAP_INCLUDE_DIR}
   ${JSON_INCLUDE_DIR}
   ${CXXOPTS_INCLUDE_DIR}
+  ${STB_INCLUDE_DIR}
   ${CPPCODEC_INCLUDE_DIR}
   ${FMT_INCLUDE_DIR}
 )

--- a/src/Fbx2Raw.cpp
+++ b/src/Fbx2Raw.cpp
@@ -104,7 +104,7 @@ struct FbxRoughMetMaterialInfo : FbxMaterialInfo {
         : FbxMaterialInfo(name, shadingModel)
     {}
     const FbxFileTexture *texColor {};
-    FbxVector4           colBase { 1, 1, 1, 1 };
+    FbxVector4           colBase {};
     const FbxFileTexture *texNormal {};
     const FbxFileTexture *texMetallic {};
     FbxDouble            metallic {};
@@ -137,12 +137,14 @@ struct FbxRoughMetMaterialInfo : FbxMaterialInfo {
             if (useProp.IsValid() && useProp.Get<bool>()) {
                 const FbxProperty texProp = mayaProp.FindHierarchical(("TEX_" + propName + "_map").c_str());
                 if (texProp.IsValid()) {
-                    fmt::printf("%s property type for material %s: %s\n", propName, fbxMaterial->GetName(), texProp.GetPropertyDataType().GetName());
                     ptr = texProp.GetSrcObject<FbxFileTexture>();
                     if (ptr != nullptr && textureLocations.find(ptr) == textureLocations.end()) {
                         ptr = nullptr;
                     }
                 }
+            } else if (verboseOutput && useProp.IsValid()) {
+                fmt::printf("Note: Property '%s' of material '%s' exists, but is flagged as 'do not use'.\n",
+                    propName, fbxMaterial->GetName());
             }
             return ptr;
         };

--- a/src/Fbx2Raw.cpp
+++ b/src/Fbx2Raw.cpp
@@ -88,51 +88,47 @@ private:
     const FbxLayerElementArrayTemplate<int>    *indices;
 };
 
-class FbxRoughMetMaterialAccess
-{
-    struct FbxMaterialProperties {
-        const FbxFileTexture *texColor {};
-        FbxVector4           colBase { 1, 1, 1, 1 };
-        const FbxFileTexture *texNormal {};
-        const FbxFileTexture *texMetallic {};
-        FbxDouble            metallic {};
-        const FbxFileTexture *texRoughness {};
-        FbxDouble            roughness {};
-        const FbxFileTexture *texEmissive {};
-        FbxVector4           colEmissive {};
-        FbxDouble            emissiveIntensity;
-        const FbxFileTexture *texAmbientOcclusion {};
-    };
-
-private:
-    const FbxSurfaceMaterial *fbxMaterial;
-    const std::map<const FbxTexture *, FbxString> &textureLocations;
-
-public:
+struct FbxMaterialInfo {
+    FbxMaterialInfo(const FbxString &name, const FbxString &shadingModel)
+        : name(name),
+          shadingModel(shadingModel)
+    {}
     const FbxString name;
     const FbxString shadingModel;
+};
 
-    const struct FbxMaterialProperties props;
+struct FbxRoughMetMaterialInfo : FbxMaterialInfo {
+    static constexpr const char *FBX_SHADER_METROUGH = "MetallicRoughness";
 
-    explicit FbxRoughMetMaterialAccess(
-        const FbxSurfaceMaterial *fbxMaterial, const std::map<const FbxTexture *, FbxString> &textureNames) :
-        fbxMaterial(fbxMaterial),
-        name(fbxMaterial->GetName()),
-        shadingModel(fbxMaterial->ShadingModel),
-        textureLocations(textureNames),
-        props(extractTextures())
+    FbxRoughMetMaterialInfo(const FbxString &name, const FbxString &shadingModel)
+        : FbxMaterialInfo(name, shadingModel)
     {}
+    const FbxFileTexture *texColor {};
+    FbxVector4           colBase { 1, 1, 1, 1 };
+    const FbxFileTexture *texNormal {};
+    const FbxFileTexture *texMetallic {};
+    FbxDouble            metallic {};
+    const FbxFileTexture *texRoughness {};
+    FbxDouble            roughness {};
+    const FbxFileTexture *texEmissive {};
+    FbxVector4           colEmissive {};
+    FbxDouble            emissiveIntensity {};
+    const FbxFileTexture *texAmbientOcclusion {};
 
-    struct FbxMaterialProperties extractTextures() {
-        struct FbxMaterialProperties res { };
+    static std::unique_ptr<FbxRoughMetMaterialInfo> From(
+        FbxSurfaceMaterial *fbxMaterial,
+        const std::map<const FbxTexture *, FbxString> &textureLocations)
+    {
+        std::unique_ptr<FbxRoughMetMaterialInfo> res(new FbxRoughMetMaterialInfo(fbxMaterial->GetName(), FBX_SHADER_METROUGH));
 
         const FbxProperty mayaProp = fbxMaterial->FindProperty("Maya");
         if (mayaProp.GetPropertyDataType() != FbxCompoundDT) {
-            return res;
+            return nullptr;
         }
-        auto foo = mayaProp.GetPropertyDataType();
-
-        fmt::printf("Maya property type for material %s: %s\n", fbxMaterial->GetName(), foo.GetName());
+        if (!fbxMaterial->ShadingModel.Get().IsEmpty()) {
+            fmt::printf("Warning: Material %s has surprising shading model: %s\n",
+                fbxMaterial->GetName(), fbxMaterial->ShadingModel.Get());
+        }
 
         auto getTex = [&](std::string propName) {
             const FbxFileTexture *ptr = nullptr;
@@ -143,62 +139,128 @@ public:
                 if (texProp.IsValid()) {
                     fmt::printf("%s property type for material %s: %s\n", propName, fbxMaterial->GetName(), texProp.GetPropertyDataType().GetName());
                     ptr = texProp.GetSrcObject<FbxFileTexture>();
+                    if (ptr != nullptr && textureLocations.find(ptr) == textureLocations.end()) {
+                        ptr = nullptr;
+                    }
                 }
             }
             return ptr;
         };
 
-        res.texNormal = getTex("normal");
-        res.texColor = getTex("color");
-        res.texAmbientOcclusion = getTex("ao");
-        res.texEmissive = getTex("emissive");
-        res.texMetallic = getTex("metallic");
-        res.texRoughness = getTex("roughness");
+        auto getVec = [&](std::string propName) -> FbxDouble3 {
+            const FbxProperty vecProp = mayaProp.FindHierarchical(propName.c_str());
+            return vecProp.IsValid() ? vecProp.Get<FbxDouble3>() : FbxDouble3(1, 1, 1);
+        };
+
+        auto getVal = [&](std::string propName) -> FbxDouble {
+            const FbxProperty vecProp = mayaProp.FindHierarchical(propName .c_str());
+            return vecProp.IsValid() ? vecProp.Get<FbxDouble>() : 0;
+        };
+
+        res->texNormal = getTex("normal");
+        res->texColor = getTex("color");
+        res->colBase = getVec("base_color");
+        res->texAmbientOcclusion = getTex("ao");
+        res->texEmissive = getTex("emissive");
+        res->colEmissive = getVec("emissive");
+        res->emissiveIntensity = getVal("emissive_intensity");
+        res->texMetallic = getTex("metallic");
+        res->metallic = getVal("metallic");
+        res->texRoughness = getTex("roughness");
+        res->roughness = getVal("roughness");
 
         return res;
     }
 };
 
-class FbxMaterialAccess
-{
-    struct FbxMaterialProperties {
-        FbxFileTexture *texAmbient {};
-        FbxVector4     colAmbient {};
-        FbxFileTexture *texSpecular {};
-        FbxVector4     colSpecular {};
-        FbxFileTexture *texDiffuse {};
-        FbxVector4     colDiffuse {};
-        FbxFileTexture *texEmissive {};
-        FbxVector4     colEmissive {};
-        FbxFileTexture *texNormal {};
-        FbxFileTexture *texShininess {};
-        FbxDouble      shininess {};
-    };
+struct FbxTraditionalMaterialInfo : FbxMaterialInfo {
+    static constexpr const char *FBX_SHADER_LAMBERT = "Lambert";
+    static constexpr const char *FBX_SHADER_BLINN   = "Blinn";
+    static constexpr const char *FBX_SHADER_PHONG   = "Phong";
 
-private:
-    const FbxSurfaceMaterial *fbxMaterial;
-    const std::map<const FbxTexture *, FbxString> &textureLocations;
-
-public:
-    const FbxString name;
-    const FbxString shadingModel;
-
-    const struct FbxMaterialProperties props;
-
-    explicit FbxMaterialAccess(
-        const FbxSurfaceMaterial *fbxMaterial, const std::map<const FbxTexture *, FbxString> &textureNames) :
-        fbxMaterial(fbxMaterial),
-        name(fbxMaterial->GetName()),
-        shadingModel(fbxMaterial->ShadingModel),
-        textureLocations(textureNames),
-        props(extractTextures())
+    FbxTraditionalMaterialInfo(const FbxString &name, const FbxString &shadingModel)
+        : FbxMaterialInfo(name, shadingModel)
     {}
 
-    struct FbxMaterialProperties extractTextures() {
-        struct FbxMaterialProperties res;
+    FbxFileTexture *texAmbient {};
+    FbxVector4     colAmbient {};
+    FbxFileTexture *texSpecular {};
+    FbxVector4     colSpecular {};
+    FbxFileTexture *texDiffuse {};
+    FbxVector4     colDiffuse {};
+    FbxFileTexture *texEmissive {};
+    FbxVector4     colEmissive {};
+    FbxFileTexture *texNormal {};
+    FbxFileTexture *texShininess {};
+    FbxDouble      shininess {};
+
+    static std::unique_ptr<FbxTraditionalMaterialInfo> From(
+        FbxSurfaceMaterial *fbxMaterial,
+        const std::map<const FbxTexture *, FbxString> &textureLocations)
+    {
+        auto getSurfaceScalar = [&](const char *propName) -> std::tuple<FbxDouble, FbxFileTexture *> {
+            const FbxProperty prop = fbxMaterial->FindProperty(propName);
+
+            FbxDouble val(0);
+            FbxFileTexture *tex = prop.GetSrcObject<FbxFileTexture>();
+            if (tex != nullptr && textureLocations.find(tex) == textureLocations.end()) {
+                tex = nullptr;
+            }
+            if (tex == nullptr && prop.IsValid()) {
+                val = prop.Get<FbxDouble>();
+            }
+            return std::make_tuple(val, tex);
+        };
+
+        auto getSurfaceVector = [&](const char *propName) -> std::tuple<FbxDouble3, FbxFileTexture *> {
+            const FbxProperty prop = fbxMaterial->FindProperty(propName);
+
+            FbxDouble3 val(1, 1, 1);
+            FbxFileTexture *tex = prop.GetSrcObject<FbxFileTexture>();
+            if (tex != nullptr && textureLocations.find(tex) == textureLocations.end()) {
+                tex = nullptr;
+            }
+            if (tex == nullptr && prop.IsValid()) {
+                val = prop.Get<FbxDouble3>();
+            }
+            return std::make_tuple(val, tex);
+        };
+
+        auto getSurfaceValues = [&](const char *colName, const char *facName) -> std::tuple<FbxVector4, FbxFileTexture *, FbxFileTexture *> {
+            const FbxProperty colProp = fbxMaterial->FindProperty(colName);
+            const FbxProperty facProp = fbxMaterial->FindProperty(facName);
+
+            FbxDouble3 colorVal(1, 1, 1);
+            FbxDouble  factorVal(1);
+
+            FbxFileTexture *colTex = colProp.GetSrcObject<FbxFileTexture>();
+            if (colTex != nullptr && textureLocations.find(colTex) == textureLocations.end()) {
+                colTex = nullptr;
+            }
+            if (colTex == nullptr && colProp.IsValid()) {
+                colorVal = colProp.Get<FbxDouble3>();
+            }
+            FbxFileTexture *facTex = facProp.GetSrcObject<FbxFileTexture>();
+            if (facTex != nullptr && textureLocations.find(facTex) == textureLocations.end()) {
+                facTex = nullptr;
+            }
+            if (facTex == nullptr && facProp.IsValid()) {
+                factorVal = facProp.Get<FbxDouble>();
+            }
+
+            auto val = FbxVector4(
+                colorVal[0] * factorVal,
+                colorVal[1] * factorVal,
+                colorVal[2] * factorVal,
+                factorVal);
+            return std::make_tuple(val, colTex, facTex);
+        };
+
+        std::string name = fbxMaterial->GetName();
+        std::unique_ptr<FbxTraditionalMaterialInfo> res(new FbxTraditionalMaterialInfo(name.c_str(), fbxMaterial->sShadingModel));
 
         // four properties are on the same structure and follow the same rules
-        auto handleBasicProperty = [&](const char *colName, const char *facName) {
+        auto handleBasicProperty = [&](const char *colName, const char *facName) -> std::tuple<FbxVector4, FbxFileTexture *>{
             FbxFileTexture *colTex, *facTex;
             FbxVector4     vec;
 
@@ -212,20 +274,20 @@ public:
             return std::make_tuple(vec, facTex);
         };
 
-        std::tie(res.colAmbient, res.texAmbient) =
+        std::tie(res->colAmbient, res->texAmbient) =
             handleBasicProperty(FbxSurfaceMaterial::sAmbient, FbxSurfaceMaterial::sAmbientFactor);
-        std::tie(res.colSpecular, res.texSpecular) =
+        std::tie(res->colSpecular, res->texSpecular) =
             handleBasicProperty(FbxSurfaceMaterial::sSpecular, FbxSurfaceMaterial::sSpecularFactor);
-        std::tie(res.colDiffuse, res.texDiffuse) =
+        std::tie(res->colDiffuse, res->texDiffuse) =
             handleBasicProperty(FbxSurfaceMaterial::sDiffuse, FbxSurfaceMaterial::sDiffuseFactor);
-        std::tie(res.colEmissive, res.texEmissive) =
+        std::tie(res->colEmissive, res->texEmissive) =
             handleBasicProperty(FbxSurfaceMaterial::sEmissive, FbxSurfaceMaterial::sEmissiveFactor);
 
         // the normal map can only ever be a map, ignore everything else
-        std::tie(std::ignore, res.texNormal) = getSurfaceVector(FbxSurfaceMaterial::sNormalMap);
+        std::tie(std::ignore, res->texNormal) = getSurfaceVector(FbxSurfaceMaterial::sNormalMap);
 
         // shininess can be a map or a factor
-        std::tie(res.shininess, res.texShininess) = getSurfaceScalar(FbxSurfaceMaterial::sShininess);
+        std::tie(res->shininess, res->texShininess) = getSurfaceScalar(FbxSurfaceMaterial::sShininess);
 
         // for transparency we just want a constant vector value;
         FbxVector4 transparency;
@@ -240,73 +302,23 @@ public:
             fmt::printf("Warning: Mat [%s]: Can't handle texture for %s; discarding.\n", name, FbxSurfaceMaterial::sTransparencyFactor);
         }
         // FBX color is RGB, so we calculate the A channel as the average of the FBX transparency color vector
-        res.colDiffuse[3] = 1.0 - (transparency[0] + transparency[1] + transparency[2])/3.0;
+        res->colDiffuse[3] = 1.0 - (transparency[0] + transparency[1] + transparency[2])/3.0;
 
         return res;
     }
-
-    std::tuple<FbxDouble, FbxFileTexture *> getSurfaceScalar(const char *propName) const
-    {
-        const FbxProperty prop = fbxMaterial->FindProperty(propName);
-
-        FbxDouble val(0);
-        FbxFileTexture *tex = prop.GetSrcObject<FbxFileTexture>();
-        if (tex != nullptr && textureLocations.find(tex) == textureLocations.end()) {
-            tex = nullptr;
-        }
-        if (tex == nullptr && prop.IsValid()) {
-            val = prop.Get<FbxDouble>();
-        }
-        return std::make_tuple(val, tex);
-    }
-
-    std::tuple<FbxDouble3, FbxFileTexture *> getSurfaceVector(const char *propName) const
-    {
-        const FbxProperty prop = fbxMaterial->FindProperty(propName);
-
-        FbxDouble3 val(1, 1, 1);
-        FbxFileTexture *tex = prop.GetSrcObject<FbxFileTexture>();
-        if (tex != nullptr && textureLocations.find(tex) == textureLocations.end()) {
-            tex = nullptr;
-        }
-        if (tex == nullptr && prop.IsValid()) {
-            val = prop.Get<FbxDouble3>();
-        }
-        return std::make_tuple(val, tex);
-    }
-
-    std::tuple<FbxVector4, FbxFileTexture *, FbxFileTexture *> getSurfaceValues(const char *colName, const char *facName) const
-    {
-        const FbxProperty colProp = fbxMaterial->FindProperty(colName);
-        const FbxProperty facProp = fbxMaterial->FindProperty(facName);
-
-        FbxDouble3 colorVal(1, 1, 1);
-        FbxDouble  factorVal(1);
-
-        FbxFileTexture *colTex = colProp.GetSrcObject<FbxFileTexture>();
-        if (colTex != nullptr && textureLocations.find(colTex) == textureLocations.end()) {
-            colTex = nullptr;
-        }
-        if (colTex == nullptr && colProp.IsValid()) {
-            colorVal = colProp.Get<FbxDouble3>();
-        }
-        FbxFileTexture *facTex = facProp.GetSrcObject<FbxFileTexture>();
-        if (facTex != nullptr && textureLocations.find(facTex) == textureLocations.end()) {
-            facTex = nullptr;
-        }
-        if (facTex == nullptr && facProp.IsValid()) {
-            factorVal = facProp.Get<FbxDouble>();
-        }
-
-        auto val = FbxVector4(
-            colorVal[0] * factorVal,
-            colorVal[1] * factorVal,
-            colorVal[2] * factorVal,
-            factorVal);
-        return std::make_tuple(val, colTex, facTex);
-    };
 };
 
+
+std::unique_ptr<FbxMaterialInfo>
+GetMaterialInfo(FbxSurfaceMaterial *material, const std::map<const FbxTexture *, FbxString> &textureLocations)
+{
+    std::unique_ptr<FbxMaterialInfo> res;
+    res = FbxRoughMetMaterialInfo::From(material, textureLocations);
+    if (!res) {
+        res = FbxTraditionalMaterialInfo::From(material, textureLocations);
+    }
+    return res;
+}
 
 class FbxMaterialsAccess
 {
@@ -345,14 +357,14 @@ public:
             }
             auto summary = summaries[materialNum];
             if (summary == nullptr) {
-                summary = summaries[materialNum] = std::make_shared<FbxRoughMetMaterialAccess>(
+                summary = summaries[materialNum] = GetMaterialInfo(
                     mesh->GetNode()->GetSrcObject<FbxSurfaceMaterial>(materialNum),
                     textureLocations);
             }
         }
     }
 
-    const std::shared_ptr<FbxRoughMetMaterialAccess> GetMaterial(const int polygonIndex) const
+    const std::shared_ptr<FbxMaterialInfo> GetMaterial(const int polygonIndex) const
     {
         if (mappingMode != FbxGeometryElement::eNone) {
             const int materialNum = indices->GetAt((mappingMode == FbxGeometryElement::eByPolygon) ? polygonIndex : 0);
@@ -365,10 +377,10 @@ public:
     }
 
 private:
-    FbxGeometryElement::EMappingMode                mappingMode;
-    std::vector<std::shared_ptr<FbxRoughMetMaterialAccess>> summaries {};
-    const FbxMesh                                   *mesh;
-    const FbxLayerElementArrayTemplate<int>         *indices;
+    FbxGeometryElement::EMappingMode              mappingMode;
+    std::vector<std::shared_ptr<FbxMaterialInfo>> summaries {};
+    const FbxMesh                                 *mesh;
+    const FbxLayerElementArrayTemplate<int>       *indices;
 };
 
 class FbxSkinningAccess
@@ -757,15 +769,14 @@ static void ReadMesh(RawModel &raw, FbxScene *pScene, FbxNode *pNode, const std:
     for (int polygonIndex = 0; polygonIndex < pMesh->GetPolygonCount(); polygonIndex++) {
         FBX_ASSERT(pMesh->GetPolygonSize(polygonIndex) == 3);
 
-        const std::shared_ptr<FbxRoughMetMaterialAccess> fbxMaterial = materials.GetMaterial(polygonIndex);
-
-        int textures[RAW_TEXTURE_USAGE_MAX];
+        int textures[RAW_TEXTURE_USAGE_MAX] { -1 };
         std::fill_n(textures, RAW_TEXTURE_USAGE_MAX, -1);
 
         FbxString  shadingModel, materialName;
         FbxVector4 ambient, specular, diffuse, emissive;
-        FbxDouble  shininess;
+        FbxDouble  shininess, emissiveIntensity, metallic, roughness;
 
+        const std::shared_ptr<FbxMaterialInfo> fbxMaterial = materials.GetMaterial(polygonIndex);
         if (fbxMaterial == nullptr) {
             materialName = "DefaultMaterial";
             shadingModel = "Lambert";
@@ -773,8 +784,6 @@ static void ReadMesh(RawModel &raw, FbxScene *pScene, FbxNode *pNode, const std:
         } else {
             materialName = fbxMaterial->name;
             shadingModel = fbxMaterial->shadingModel;
-
-            const auto &matProps = fbxMaterial->props;
 
             const auto maybeAddTexture = [&](const FbxFileTexture *tex, RawTextureUsage usage) {
                 if (tex != nullptr) {
@@ -784,12 +793,37 @@ static void ReadMesh(RawModel &raw, FbxScene *pScene, FbxNode *pNode, const std:
                 }
             };
 
-            maybeAddTexture(matProps.texColor, RAW_TEXTURE_USAGE_ALBEDO);
-            maybeAddTexture(matProps.texNormal, RAW_TEXTURE_USAGE_NORMAL);
-            maybeAddTexture(matProps.texEmissive, RAW_TEXTURE_USAGE_EMISSIVE);
-            maybeAddTexture(matProps.texRoughness, RAW_TEXTURE_USAGE_ROUGHNESS);
-            maybeAddTexture(matProps.texMetallic, RAW_TEXTURE_USAGE_METALLIC);
-            maybeAddTexture(matProps.texAmbientOcclusion, RAW_TEXTURE_USAGE_OCCLUSION);
+            if (shadingModel == FbxRoughMetMaterialInfo::FBX_SHADER_METROUGH) {
+                FbxRoughMetMaterialInfo *matProps = static_cast<FbxRoughMetMaterialInfo *>(fbxMaterial.get());
+
+                maybeAddTexture(matProps->texColor, RAW_TEXTURE_USAGE_ALBEDO);
+                diffuse = matProps->colBase;
+                maybeAddTexture(matProps->texNormal, RAW_TEXTURE_USAGE_NORMAL);
+                maybeAddTexture(matProps->texEmissive, RAW_TEXTURE_USAGE_EMISSIVE);
+                emissive = matProps->colEmissive;
+                emissiveIntensity = matProps->emissiveIntensity;
+                maybeAddTexture(matProps->texRoughness, RAW_TEXTURE_USAGE_ROUGHNESS);
+                maybeAddTexture(matProps->texMetallic, RAW_TEXTURE_USAGE_METALLIC);
+                metallic = matProps->metallic;
+                maybeAddTexture(matProps->texAmbientOcclusion, RAW_TEXTURE_USAGE_OCCLUSION);
+                roughness = matProps->roughness;
+            } else {
+
+                FbxTraditionalMaterialInfo *matProps = static_cast<FbxTraditionalMaterialInfo *>(fbxMaterial.get());
+
+                maybeAddTexture(matProps->texDiffuse, RAW_TEXTURE_USAGE_DIFFUSE);
+                diffuse = matProps->colDiffuse;
+                maybeAddTexture(matProps->texNormal, RAW_TEXTURE_USAGE_NORMAL);
+                maybeAddTexture(matProps->texEmissive, RAW_TEXTURE_USAGE_EMISSIVE);
+                emissive = matProps->colEmissive;
+                maybeAddTexture(matProps->texShininess, RAW_TEXTURE_USAGE_SHININESS);
+                shininess = matProps->shininess;
+                maybeAddTexture(matProps->texAmbient, RAW_TEXTURE_USAGE_AMBIENT);
+                ambient = matProps->colAmbient;
+                maybeAddTexture(matProps->texSpecular, RAW_TEXTURE_USAGE_SPECULAR);
+                specular = matProps->colSpecular;
+            }
+
         }
 
         RawVertex rawVertices[3];
@@ -919,7 +953,8 @@ static void ReadMesh(RawModel &raw, FbxScene *pScene, FbxNode *pNode, const std:
         const RawMaterialType materialType = GetMaterialType(raw, textures, vertexTransparency, skinning.IsSkinned());
         const int rawMaterialIndex = raw.AddMaterial(
             materialName, shadingModel, materialType, textures,
-            toVec3f(ambient), toVec4f(diffuse), toVec3f(specular), toVec3f(emissive), shininess);
+            toVec3f(ambient), toVec4f(diffuse), toVec3f(specular), toVec3f(emissive),
+            emissiveIntensity, shininess, metallic, roughness);
 
         raw.AddTriangle(rawVertexIndices[0], rawVertexIndices[1], rawVertexIndices[2], rawMaterialIndex, rawSurfaceIndex);
     }

--- a/src/Raw2Gltf.cpp
+++ b/src/Raw2Gltf.cpp
@@ -428,10 +428,10 @@ ModelData *Raw2Gltf(
                 explicit TexInfo(int rawTexIx) : rawTexIx(rawTexIx) {}
 
                 const int rawTexIx;
-                int width;
-                int height;
-                int channels;
-                uint8_t *pixels;
+                int width {};
+                int height {};
+                int channels {};
+                uint8_t *pixels {};
             };
 
             int width = -1, height = -1;

--- a/src/Raw2Gltf.cpp
+++ b/src/Raw2Gltf.cpp
@@ -565,11 +565,7 @@ ModelData *Raw2Gltf(
                 // albedo is basic
                 const TextureData *albedoTex = simpleTex(RAW_TEXTURE_USAGE_ALBEDO);
 
-                // if there's a met/rough texture, just set the factors to 1.0 multipliers, else use reasonable
-                // defaults for a possible vertex-coloured or solid colour setup
-                float metallic  = metRoughTex ? 1.0f : 0.3f;
-                float roughness = metRoughTex ? 1.0f : 0.6f;
-                pbrMetRough.reset(new PBRMetallicRoughness(albedoTex, metRoughTex, material.diffuseFactor, metallic, roughness));
+                pbrMetRough.reset(new PBRMetallicRoughness(albedoTex, metRoughTex, material.diffuseFactor, material.metallic, material.roughness));
             }
 
             std::shared_ptr<PBRSpecularGlossiness> pbrSpecGloss;
@@ -601,7 +597,7 @@ ModelData *Raw2Gltf(
             std::shared_ptr<MaterialData> mData = gltf->materials.hold(
                 new MaterialData(
                     material.name, isTransparent, simpleTex(RAW_TEXTURE_USAGE_NORMAL),
-                    simpleTex(RAW_TEXTURE_USAGE_EMISSIVE), material.emissiveFactor,
+                    simpleTex(RAW_TEXTURE_USAGE_EMISSIVE), material.emissiveFactor * material.emissiveIntensity, // TODO: 1.0 default value for emissiveIntensity?
                     khrComMat, pbrMetRough, pbrSpecGloss));
             materialsByName[materialHash(material)] = mData;
         }

--- a/src/Raw2Gltf.cpp
+++ b/src/Raw2Gltf.cpp
@@ -21,7 +21,6 @@
 #include "utils/String_Utils.h"
 #include "utils/Image_Utils.h"
 #include <utils/File_Utils.h>
-#include <tiff.h>
 #include "RawModel.h"
 #include "Raw2Gltf.h"
 

--- a/src/Raw2Gltf.cpp
+++ b/src/Raw2Gltf.cpp
@@ -425,7 +425,10 @@ ModelData *Raw2Gltf(
 
             std::shared_ptr<PBRMetallicRoughness> pbrMetRough;
             if (options.usePBRMetRough) {
-                pbrMetRough.reset(new PBRMetallicRoughness(getTex(RAW_TEXTURE_USAGE_DIFFUSE), material.diffuseFactor));
+                pbrMetRough.reset(new PBRMetallicRoughness(
+                    getTex(RAW_TEXTURE_USAGE_ALBEDO),
+                    getTex(RAW_TEXTURE_USAGE_ROUGHNESS), // TODO: do actual layer-baking!
+                    material.diffuseFactor));
             }
             std::shared_ptr<PBRSpecularGlossiness> pbrSpecGloss;
             if (options.usePBRSpecGloss) {

--- a/src/RawModel.cpp
+++ b/src/RawModel.cpp
@@ -113,14 +113,14 @@ int RawModel::AddMaterial(const RawMaterial &material)
 {
     return AddMaterial(
         material.name.c_str(), material.shadingModel.c_str(), material.type, material.textures, material.ambientFactor,
-        material.diffuseFactor, material.specularFactor, material.emissiveFactor, material.shininess);
+        material.diffuseFactor, material.specularFactor, material.emissiveFactor, material.emissiveIntensity,
+        material.shininess, material.metallic, material.roughness);
 }
 
 int RawModel::AddMaterial(
-    const char *name, const char *shadingModel, const RawMaterialType materialType,
-    const int textures[RAW_TEXTURE_USAGE_MAX], const Vec3f ambientFactor,
-    const Vec4f diffuseFactor, const Vec3f specularFactor,
-    const Vec3f emissiveFactor, float shinineness)
+    const char *name, const char *shadingModel, const RawMaterialType materialType, const int textures[RAW_TEXTURE_USAGE_MAX],
+    const Vec3f ambientFactor, const Vec4f diffuseFactor, const Vec3f specularFactor, const Vec3f emissiveFactor,
+    float emissiveIntensity, float shinineness, float metallic, float roughness)
 {
     for (size_t i = 0; i < materials.size(); i++) {
         if (materials[i].name != name) {
@@ -136,7 +136,10 @@ int RawModel::AddMaterial(
             materials[i].diffuseFactor != diffuseFactor ||
             materials[i].specularFactor != specularFactor ||
             materials[i].emissiveFactor != emissiveFactor ||
-            materials[i].shininess != shinineness) {
+            materials[i].emissiveIntensity != emissiveIntensity ||
+            materials[i].shininess != shinineness ||
+            materials[i].metallic != metallic ||
+            materials[i].roughness != roughness) {
             continue;
         }
 
@@ -150,14 +153,17 @@ int RawModel::AddMaterial(
     }
 
     RawMaterial material;
-    material.name           = name;
-    material.shadingModel   = shadingModel;
-    material.type           = materialType;
-    material.ambientFactor  = ambientFactor;
-    material.diffuseFactor  = diffuseFactor;
-    material.specularFactor = specularFactor;
-    material.emissiveFactor = emissiveFactor;
-    material.shininess      = shinineness;
+    material.name              = name;
+    material.shadingModel      = shadingModel;
+    material.type              = materialType;
+    material.ambientFactor     = ambientFactor;
+    material.diffuseFactor     = diffuseFactor;
+    material.specularFactor    = specularFactor;
+    material.emissiveFactor    = emissiveFactor;
+    material.emissiveIntensity = emissiveIntensity;
+    material.shininess         = shinineness;
+    material.metallic          = metallic;
+    material.roughness         = roughness;
 
     for (int i = 0; i < RAW_TEXTURE_USAGE_MAX; i++) {
         material.textures[i] = textures[i];

--- a/src/RawModel.cpp
+++ b/src/RawModel.cpp
@@ -111,38 +111,25 @@ int RawModel::AddTexture(const std::string &name, const std::string &fileName, c
 
 int RawModel::AddMaterial(const RawMaterial &material)
 {
-    return AddMaterial(
-        material.name.c_str(), material.shadingModel.c_str(), material.type, material.textures, material.ambientFactor,
-        material.diffuseFactor, material.specularFactor, material.emissiveFactor, material.emissiveIntensity,
-        material.shininess, material.metallic, material.roughness);
+    return AddMaterial(material.name.c_str(), material.type, material.textures, material.info);
 }
 
 int RawModel::AddMaterial(
-    const char *name, const char *shadingModel, const RawMaterialType materialType, const int textures[RAW_TEXTURE_USAGE_MAX],
-    const Vec3f ambientFactor, const Vec4f diffuseFactor, const Vec3f specularFactor, const Vec3f emissiveFactor,
-    float emissiveIntensity, float shinineness, float metallic, float roughness)
+    const char *name,
+    const RawMaterialType materialType,
+    const int textures[RAW_TEXTURE_USAGE_MAX],
+    std::shared_ptr<RawMatProps> materialInfo)
 {
     for (size_t i = 0; i < materials.size(); i++) {
         if (materials[i].name != name) {
             continue;
         }
-        if (materials[i].shadingModel != shadingModel) {
-            continue;
-        }
         if (materials[i].type != materialType) {
             continue;
         }
-        if (materials[i].ambientFactor != ambientFactor ||
-            materials[i].diffuseFactor != diffuseFactor ||
-            materials[i].specularFactor != specularFactor ||
-            materials[i].emissiveFactor != emissiveFactor ||
-            materials[i].emissiveIntensity != emissiveIntensity ||
-            materials[i].shininess != shinineness ||
-            materials[i].metallic != metallic ||
-            materials[i].roughness != roughness) {
+        if (*(materials[i].info) != *materialInfo) {
             continue;
         }
-
         bool match = true;
         for (int j = 0; match && j < RAW_TEXTURE_USAGE_MAX; j++) {
             match = match && (materials[i].textures[j] == textures[j]);
@@ -153,17 +140,9 @@ int RawModel::AddMaterial(
     }
 
     RawMaterial material;
-    material.name              = name;
-    material.shadingModel      = shadingModel;
-    material.type              = materialType;
-    material.ambientFactor     = ambientFactor;
-    material.diffuseFactor     = diffuseFactor;
-    material.specularFactor    = specularFactor;
-    material.emissiveFactor    = emissiveFactor;
-    material.emissiveIntensity = emissiveIntensity;
-    material.shininess         = shinineness;
-    material.metallic          = metallic;
-    material.roughness         = roughness;
+    material.name = name;
+    material.type = materialType;
+    material.info = materialInfo;
 
     for (int i = 0; i < RAW_TEXTURE_USAGE_MAX; i++) {
         material.textures[i] = textures[i];

--- a/src/RawModel.h
+++ b/src/RawModel.h
@@ -104,6 +104,10 @@ enum RawTextureUsage
     RAW_TEXTURE_USAGE_SHININESS,
     RAW_TEXTURE_USAGE_EMISSIVE,
     RAW_TEXTURE_USAGE_REFLECTION,
+    RAW_TEXTURE_USAGE_ALBEDO,
+    RAW_TEXTURE_USAGE_OCCLUSION,
+    RAW_TEXTURE_USAGE_ROUGHNESS,
+    RAW_TEXTURE_USAGE_METALLIC,
     RAW_TEXTURE_USAGE_MAX
 };
 
@@ -127,6 +131,12 @@ inline std::string DescribeTextureUsage(int usage)
             return "emissive";
         case RAW_TEXTURE_USAGE_REFLECTION:
             return "reflection";
+        case RAW_TEXTURE_USAGE_OCCLUSION:
+            return "occlusion";
+        case RAW_TEXTURE_USAGE_ROUGHNESS:
+            return "roughness";
+        case RAW_TEXTURE_USAGE_METALLIC:
+            return "metallic";
         case RAW_TEXTURE_USAGE_MAX:
         default:
             return "unknown";

--- a/src/RawModel.h
+++ b/src/RawModel.h
@@ -179,7 +179,10 @@ struct RawMaterial
     Vec4f           diffuseFactor;
     Vec3f           specularFactor;
     Vec3f           emissiveFactor;
+    float           emissiveIntensity;
     float           shininess;
+    float           metallic;
+    float           roughness;
     int             textures[RAW_TEXTURE_USAGE_MAX];
 };
 
@@ -272,10 +275,9 @@ public:
     int AddTexture(const std::string &name, const std::string &fileName, const std::string &fileLocation, RawTextureUsage usage);
     int AddMaterial(const RawMaterial &material);
     int AddMaterial(
-        const char *name, const char *shadingModel, RawMaterialType materialType,
-        const int textures[RAW_TEXTURE_USAGE_MAX], Vec3f ambientFactor,
-        Vec4f diffuseFactor, Vec3f specularFactor,
-        Vec3f emissiveFactor, float shinineness);
+        const char *name, const char *shadingModel, const RawMaterialType materialType, const int textures[RAW_TEXTURE_USAGE_MAX],
+        const Vec3f ambientFactor, const Vec4f diffuseFactor, const Vec3f specularFactor, const Vec3f emissiveFactor,
+        float emissiveIntensity, float shinineness, float metallic, float roughness);
     int AddSurface(const RawSurface &suface);
     int AddSurface(const char *name, const char *nodeName);
     int AddAnimation(const RawAnimation &animation);

--- a/src/RawModel.h
+++ b/src/RawModel.h
@@ -95,8 +95,32 @@ struct RawTriangle
     int surfaceIndex;
 };
 
+enum RawShadingModel
+{
+    RAW_SHADING_MODEL_UNKNOWN = -1,
+    RAW_SHADING_MODEL_CONSTANT,
+    RAW_SHADING_MODEL_LAMBERT,
+    RAW_SHADING_MODEL_BLINN,
+    RAW_SHADING_MODEL_PHONG,
+    RAW_SHADING_MODEL_PBR_MET_ROUGH,
+    RAW_SHADING_MODEL_MAX
+};
+
+static inline std::string Describe(RawShadingModel model) {
+    switch(model) {
+        case RAW_SHADING_MODEL_UNKNOWN:         return "<unknown>";
+        case RAW_SHADING_MODEL_CONSTANT:        return "Constant";
+        case RAW_SHADING_MODEL_LAMBERT:         return "Lambert";
+        case RAW_SHADING_MODEL_BLINN:           return "Blinn";
+        case RAW_SHADING_MODEL_PHONG:           return "Phong";
+        case RAW_SHADING_MODEL_PBR_MET_ROUGH:   return "Metallic/Roughness";
+        case RAW_SHADING_MODEL_MAX: default:    return "<unknown>";
+    }
+}
+
 enum RawTextureUsage
 {
+    RAW_TEXTURE_USAGE_NONE = -1,
     RAW_TEXTURE_USAGE_AMBIENT,
     RAW_TEXTURE_USAGE_DIFFUSE,
     RAW_TEXTURE_USAGE_NORMAL,
@@ -111,35 +135,21 @@ enum RawTextureUsage
     RAW_TEXTURE_USAGE_MAX
 };
 
-inline std::string DescribeTextureUsage(int usage)
+static inline std::string Describe(RawTextureUsage usage)
 {
-    if (usage < 0) {
-        return "<none>";
-    }
-    switch (static_cast<RawTextureUsage>(usage)) {
-        case RAW_TEXTURE_USAGE_AMBIENT:
-            return "ambient";
-        case RAW_TEXTURE_USAGE_DIFFUSE:
-            return "diffuse";
-        case RAW_TEXTURE_USAGE_NORMAL:
-            return "normal";
-        case RAW_TEXTURE_USAGE_SPECULAR:
-            return "specuar";
-        case RAW_TEXTURE_USAGE_SHININESS:
-            return "shininess";
-        case RAW_TEXTURE_USAGE_EMISSIVE:
-            return "emissive";
-        case RAW_TEXTURE_USAGE_REFLECTION:
-            return "reflection";
-        case RAW_TEXTURE_USAGE_OCCLUSION:
-            return "occlusion";
-        case RAW_TEXTURE_USAGE_ROUGHNESS:
-            return "roughness";
-        case RAW_TEXTURE_USAGE_METALLIC:
-            return "metallic";
-        case RAW_TEXTURE_USAGE_MAX:
-        default:
-            return "unknown";
+    switch (usage) {
+        case RAW_TEXTURE_USAGE_NONE:        return "<none>";
+        case RAW_TEXTURE_USAGE_AMBIENT:     return "ambient";
+        case RAW_TEXTURE_USAGE_DIFFUSE:     return "diffuse";
+        case RAW_TEXTURE_USAGE_NORMAL:      return "normal";
+        case RAW_TEXTURE_USAGE_SPECULAR:    return "specuar";
+        case RAW_TEXTURE_USAGE_SHININESS:   return "shininess";
+        case RAW_TEXTURE_USAGE_EMISSIVE:    return "emissive";
+        case RAW_TEXTURE_USAGE_REFLECTION:  return "reflection";
+        case RAW_TEXTURE_USAGE_OCCLUSION:   return "occlusion";
+        case RAW_TEXTURE_USAGE_ROUGHNESS:   return "roughness";
+        case RAW_TEXTURE_USAGE_METALLIC:    return "metallic";
+        case RAW_TEXTURE_USAGE_MAX:default: return "unknown";
     }
 };
 
@@ -169,21 +179,91 @@ enum RawMaterialType
     RAW_MATERIAL_TYPE_SKINNED_TRANSPARENT,
 };
 
+struct RawMatProps {
+    explicit RawMatProps(RawShadingModel shadingModel)
+        : shadingModel(shadingModel)
+    {}
+    const RawShadingModel shadingModel;
+
+    virtual bool operator!=(const RawMatProps &other) const { return !(*this == other); }
+    virtual bool operator==(const RawMatProps &other) const { return shadingModel == other.shadingModel; };
+};
+
+struct RawTraditionalMatProps : RawMatProps {
+    RawTraditionalMatProps(
+        RawShadingModel shadingModel,
+        const Vec3f &&ambientFactor,
+        const Vec4f &&diffuseFactor,
+        const Vec3f &&emissiveFactor,
+        const Vec3f &&specularFactor,
+        const float shininess
+    ) : RawMatProps(shadingModel),
+          ambientFactor(ambientFactor),
+          diffuseFactor(diffuseFactor),
+          emissiveFactor(emissiveFactor),
+          specularFactor(specularFactor),
+          shininess(shininess)
+    {}
+
+    const Vec3f ambientFactor;
+    const Vec4f diffuseFactor;
+    const Vec3f emissiveFactor;
+    const Vec3f specularFactor;
+    const float shininess;
+
+    bool operator==(const RawMatProps &other) const override {
+        if (RawMatProps::operator==(other)) {
+            const auto &typed = (RawTraditionalMatProps &) other;
+            return ambientFactor == typed.ambientFactor &&
+                diffuseFactor == typed.diffuseFactor &&
+                specularFactor == typed.specularFactor &&
+                emissiveFactor == typed.emissiveFactor &&
+                shininess == typed.shininess;
+        }
+        return false;
+    }
+};
+
+struct RawMetRoughMatProps : RawMatProps {
+    RawMetRoughMatProps(
+        RawShadingModel shadingModel,
+        const Vec4f &&diffuseFactor,
+        const Vec3f &&emissiveFactor,
+        float emissiveIntensity,
+        float metallic,
+        float roughness
+    ) : RawMatProps(shadingModel),
+      diffuseFactor(diffuseFactor),
+      emissiveFactor(emissiveFactor),
+      emissiveIntensity(emissiveIntensity),
+      metallic(metallic),
+      roughness(roughness)
+    {}
+    const Vec4f diffuseFactor;
+    const Vec3f emissiveFactor;
+    const float emissiveIntensity;
+    const float metallic;
+    const float roughness;
+
+    bool operator==(const RawMatProps &other) const override {
+        if (RawMatProps::operator==(other)) {
+            const auto &typed = (RawMetRoughMatProps &) other;
+            return diffuseFactor == typed.diffuseFactor &&
+            emissiveFactor == typed.emissiveFactor &&
+            emissiveIntensity == typed.emissiveIntensity &&
+            metallic == typed.metallic &&
+            roughness == typed.roughness;
+        }
+        return false;
+    }
+};
+
 struct RawMaterial
 {
-
-    std::string     name;
-    std::string     shadingModel;    // typically "Surface", "Anisotropic", "Blinn", "Lambert", "Phong", "Phone E"
-    RawMaterialType type;
-    Vec3f           ambientFactor;
-    Vec4f           diffuseFactor;
-    Vec3f           specularFactor;
-    Vec3f           emissiveFactor;
-    float           emissiveIntensity;
-    float           shininess;
-    float           metallic;
-    float           roughness;
-    int             textures[RAW_TEXTURE_USAGE_MAX];
+    std::string                  name;
+    RawMaterialType              type;
+    std::shared_ptr<RawMatProps> info;
+    int                          textures[RAW_TEXTURE_USAGE_MAX];
 };
 
 struct RawBlendChannel
@@ -275,9 +355,8 @@ public:
     int AddTexture(const std::string &name, const std::string &fileName, const std::string &fileLocation, RawTextureUsage usage);
     int AddMaterial(const RawMaterial &material);
     int AddMaterial(
-        const char *name, const char *shadingModel, const RawMaterialType materialType, const int textures[RAW_TEXTURE_USAGE_MAX],
-        const Vec3f ambientFactor, const Vec4f diffuseFactor, const Vec3f specularFactor, const Vec3f emissiveFactor,
-        float emissiveIntensity, float shinineness, float metallic, float roughness);
+        const char *name, const RawMaterialType materialType, const int textures[RAW_TEXTURE_USAGE_MAX],
+        std::shared_ptr<RawMatProps> materialInfo);
     int AddSurface(const RawSurface &suface);
     int AddSurface(const char *name, const char *nodeName);
     int AddAnimation(const RawAnimation &animation);

--- a/src/glTF/MaterialData.cpp
+++ b/src/glTF/MaterialData.cpp
@@ -126,10 +126,11 @@ void to_json(json &j, const PBRSpecularGlossiness &d)
 }
 
 PBRMetallicRoughness::PBRMetallicRoughness(
-    const TextureData *baseColorTexture, const Vec4f &baseolorFactor,
-    float metallic, float roughness)
+    const TextureData *baseColorTexture, const TextureData *metRoughTexture,
+    const Vec4f &baseColorFactor, float metallic, float roughness)
     : baseColorTexture(Tex::ref(baseColorTexture)),
-      baseColorFactor(baseolorFactor),
+      metRoughTexture(Tex::ref(metRoughTexture)),
+      baseColorFactor(baseColorFactor),
       metallic(metallic),
       roughness(roughness)
 {
@@ -143,6 +144,9 @@ void to_json(json &j, const PBRMetallicRoughness &d)
     }
     if (d.baseColorFactor.LengthSquared() > 0) {
         j["baseColorFactor"] = toStdVec(d.baseColorFactor);
+    }
+    if (d.metRoughTexture != nullptr) {
+        j["metallicRoughnessTexture"] = *d.metRoughTexture;
     }
     if (d.metallic != 1.0f) {
         j["metallicFactor"] = d.metallic;

--- a/src/glTF/MaterialData.cpp
+++ b/src/glTF/MaterialData.cpp
@@ -147,11 +147,12 @@ void to_json(json &j, const PBRMetallicRoughness &d)
     }
     if (d.metRoughTexture != nullptr) {
         j["metallicRoughnessTexture"] = *d.metRoughTexture;
-    }
-    if (d.metallic != 1.0f) {
+        // if a texture is provided, throw away metallic/roughness values
+        j["roughnessFactor"] = 1.0f;
+        j["metallicFactor"] = 1.0f;
+    } else {
+        // without a texture, however, use metallic/roughness as constants
         j["metallicFactor"] = d.metallic;
-    }
-    if (d.roughness != 1.0f) {
         j["roughnessFactor"] = d.roughness;
     }
 }

--- a/src/glTF/MaterialData.h
+++ b/src/glTF/MaterialData.h
@@ -70,10 +70,11 @@ struct PBRSpecularGlossiness
 struct PBRMetallicRoughness
 {
     PBRMetallicRoughness(
-        const TextureData *baseColorTexture, const Vec4f &baseolorFactor,
-        float metallic = 0.1f, float roughness = 0.4f);
+        const TextureData *baseColorTexture, const TextureData *metRoughTexture,
+        const Vec4f &baseColorFactor, float metallic = 0.1f, float roughness = 0.6f);
 
     std::unique_ptr<Tex> baseColorTexture;
+    std::unique_ptr<Tex> metRoughTexture;
     const Vec4f          baseColorFactor;
     const float          metallic;
     const float          roughness;


### PR DESCRIPTION
There is no formal support for PBR parameters in FBX, but the Stingray PBS material export path gets pretty close:
- It's free with Maya, so a large proportion of artists have access to it,
- It's how Allegorithmic's Substance Painter exports (when coupled with Maya),
- It actually takes advantage FBX's extensible and hierarchical property system. Other solutions have been more arcane,

So, long story short, we can now finally both read and write PBR models.

This feature necessitated some internal refactoring, and more may be needed down the road if we add more material types. The most complex new code performs the packing of multiple data channels into a single texture, e.g. metallic and roughness occupy the blue and green channels in a common texture.

In addition to the Stingray PBS support, we also take this opportunity to improve the way we offer conversion attempts from one format to another. The most interesting conversion is probably from old workflow FBX (Lambert, Phong, etc) to PBR output -- and while this is an essentially impossible task, the results are not bad. We've leaned on @bghgary's work for this, e.g. [this code](https://github.com/KhronosGroup/glTF/blob/master/extensions/Khronos/KHR_materials_pbrSpecularGlossiness/examples/convert-between-workflows/js/three.pbrUtilities.js).

Implements https://github.com/facebookincubator/FBX2glTF/issues/12.
