### PR TITLE
Fix normal issues on some models

### DIFF
--- a/src/Fbx2Raw.cpp
+++ b/src/Fbx2Raw.cpp
@@ -739,7 +739,10 @@ static void ReadMesh(RawModel &raw, FbxScene *pScene, FbxNode *pNode, const std:
     const FbxVector4 meshScaling               = pNode->GetGeometricScaling(FbxNode::eSourcePivot);
     const FbxAMatrix meshTransform(meshTranslation, meshRotation, meshScaling);
     const FbxMatrix  transform                 = meshTransform;
-    const FbxMatrix  inverseTransposeTransform = transform.Inverse().Transpose();
+
+    // Remove translation & scaling from transforms that will bi applied to normals, tangents & binormals
+    const FbxMatrix  normalTransform(FbxVector4(), meshRotation, FbxVector4(1.0f, 1.0f, 1.0f, 1.0f));
+    const FbxMatrix  inverseTransposeTransform = normalTransform.Inverse().Transpose();
 
     raw.AddVertexAttribute(RAW_VERTEX_ATTRIBUTE_POSITION);
     if (normalLayer.LayerPresent()) { raw.AddVertexAttribute(RAW_VERTEX_ATTRIBUTE_NORMAL); }

--- a/src/Fbx2Raw.cpp
+++ b/src/Fbx2Raw.cpp
@@ -741,7 +741,7 @@ static void ReadMesh(RawModel &raw, FbxScene *pScene, FbxNode *pNode, const std:
     const FbxMatrix  transform                 = meshTransform;
 
     // Remove translation & scaling from transforms that will bi applied to normals, tangents & binormals
-    const FbxMatrix  normalTransform(FbxVector4(), meshRotation, FbxVector4(1.0f, 1.0f, 1.0f, 1.0f));
+    const FbxMatrix  normalTransform(FbxVector4(), meshRotation, meshScaling);
     const FbxMatrix  inverseTransposeTransform = normalTransform.Inverse().Transpose();
 
     raw.AddVertexAttribute(RAW_VERTEX_ATTRIBUTE_POSITION);


### PR DESCRIPTION
There is a problem with the normal channel in some models.
When a transform is applied to normal, binormal & tangents, the translation must be removed from that transaform (generally casting a mat4x4 to mat3x3).

In that case I've fixed that problem in Fbx2Raw::ReadMesh(...) method.

To test that issue, you can use that model:
https://drive.google.com/open?id=10wBSADf6y9xzNA177yIbK-u7Ek5t5etC
(Made by Willi Decarpentrie: https://sketchfab.com/models/0782a88e7ad14de9bff7953005dc2c4c)

Here with errors:
![fbx2gltf_issues](https://user-images.githubusercontent.com/1318239/33527101-28da212e-d84b-11e7-9a75-ccfb43619556.jpg)

With the fix applied:
![fbx2gltf_normalfixed](https://user-images.githubusercontent.com/1318239/33527104-37c59a06-d84b-11e7-81da-5ab1c27e68d4.jpg)


Best regards,
David Ávila, Wave Engine team member
www.waveengine.net