### PR TITLE
Fix duplicate name issues

### DIFF
--- a/src/Fbx2Raw.cpp
+++ b/src/Fbx2Raw.cpp
@@ -1114,7 +1114,7 @@ static void ReadNodeHierarchy(
     node.scale       = toVec3f(localScaling);
 
     if (parentId) {
-        RawNode &parentNode = raw.GetNode(raw.GetNodeById(nodeId));
+        RawNode &parentNode = raw.GetNode(raw.GetNodeById(parentId));
         // Add unique child name to the parent node.
         if (std::find(parentNode.childIds.begin(), parentNode.childIds.end(), nodeId) == parentNode.childIds.end()) {
             parentNode.childIds.push_back(nodeId);

--- a/src/Fbx2Raw.cpp
+++ b/src/Fbx2Raw.cpp
@@ -424,7 +424,7 @@ public:
                     inverseBindMatrices.emplace_back(globalBindposeInverseMatrix);
 
                     jointNodes.push_back(cluster->GetLink());
-                    jointNames.push_back(*cluster->GetLink()->GetName() != '\0' ? cluster->GetLink()->GetName() : cluster->GetName());
+                    jointIds.push_back(cluster->GetLink()->GetUniqueID());
 
                     const FbxAMatrix globalNodeTransform = cluster->GetLink()->EvaluateGlobalTransform();
                     jointSkinningTransforms.push_back(FbxMatrix(globalNodeTransform * globalBindposeInverseMatrix));
@@ -486,9 +486,9 @@ public:
         return jointNodes[jointIndex];
     }
 
-    const char *GetJointName(const int jointIndex) const
+    const long GetJointId(const int jointIndex) const
     {
-        return jointNames[jointIndex].c_str();
+        return jointIds[jointIndex];
     }
 
     const FbxMatrix &GetJointSkinningTransform(const int jointIndex) const
@@ -501,10 +501,10 @@ public:
         return jointInverseGlobalTransforms[jointIndex];
     }
 
-    const char *GetRootNode() const
+    const long GetRootNode() const
     {
         assert(rootIndex != -1);
-        return jointNames[rootIndex].c_str();
+        return jointIds[rootIndex];
     }
 
     const FbxAMatrix &GetInverseBindMatrix(const int jointIndex) const
@@ -526,7 +526,7 @@ public:
 
 private:
     int                      rootIndex;
-    std::vector<std::string> jointNames;
+    std::vector<long>        jointIds;
     std::vector<FbxNode *>   jointNodes;
     std::vector<FbxMatrix>   jointSkinningTransforms;
     std::vector<FbxMatrix>   jointInverseGlobalTransforms;
@@ -697,7 +697,7 @@ static void ReadMesh(RawModel &raw, FbxScene *pScene, FbxNode *pNode, const std:
     const long surfaceId = pMesh->GetUniqueID();
 
     // Associate the node to this surface
-    int nodeId = raw.GetNodeByName(pNode->GetName());
+    int nodeId = raw.GetNodeById(pNode->GetUniqueID());
     if (nodeId >= 0) {
         RawNode &node = raw.GetNode(nodeId);
         node.surfaceId = surfaceId;
@@ -724,8 +724,8 @@ static void ReadMesh(RawModel &raw, FbxScene *pScene, FbxNode *pNode, const std:
 
     if (verboseOutput) {
         fmt::printf(
-            "mesh %d: %s (skinned: %s)\n", rawSurfaceIndex, meshName,
-            skinning.IsSkinned() ? skinning.GetRootNode() : "NO");
+            "mesh %d: %s (skinned: %d)\n", rawSurfaceIndex, meshName,
+            skinning.IsSkinned() ? skinning.GetRootNode() : 0);
     }
 
     // The FbxNode geometric transformation describes how a FbxNodeAttribute is offset from
@@ -758,12 +758,12 @@ static void ReadMesh(RawModel &raw, FbxScene *pScene, FbxNode *pNode, const std:
 
     RawSurface &rawSurface = raw.GetSurface(rawSurfaceIndex);
 
-    rawSurface.skeletonRootName = (skinning.IsSkinned()) ? skinning.GetRootNode() : pNode->GetName();
+    rawSurface.skeletonRootId = (skinning.IsSkinned()) ? skinning.GetRootNode() : pNode->GetUniqueID();
     for (int jointIndex = 0; jointIndex < skinning.GetNodeCount(); jointIndex++) {
-        const char *jointName = skinning.GetJointName(jointIndex);
-        raw.GetNode(raw.GetNodeByName(jointName)).isJoint = true;
+        const long jointId = skinning.GetJointId(jointIndex);
+        raw.GetNode(raw.GetNodeById(jointId)).isJoint = true;
 
-        rawSurface.jointNames.emplace_back(jointName);
+        rawSurface.jointIds.emplace_back(jointId);
         rawSurface.inverseBindMatrices.push_back(toMat4f(skinning.GetInverseBindMatrix(jointIndex)));
         rawSurface.jointGeometryMins.emplace_back(FLT_MAX, FLT_MAX, FLT_MAX);
         rawSurface.jointGeometryMaxs.emplace_back(-FLT_MAX, -FLT_MAX, -FLT_MAX);
@@ -988,12 +988,12 @@ static void ReadCamera(RawModel &raw, FbxScene *pScene, FbxNode *pNode)
     const FbxCamera *pCamera = pNode->GetCamera();
     if (pCamera->ProjectionType.Get() == FbxCamera::EProjectionType::ePerspective) {
         raw.AddCameraPerspective(
-            "", pNode->GetName(), (float) pCamera->FilmAspectRatio,
+            "", pNode->GetUniqueID(), (float) pCamera->FilmAspectRatio,
             (float) pCamera->FieldOfViewX, (float) pCamera->FieldOfViewX,
             (float) pCamera->NearPlane, (float) pCamera->FarPlane);
     } else {
         raw.AddCameraOrthographic(
-            "", pNode->GetName(),
+            "", pNode->GetUniqueID(),
             (float) pCamera->OrthoZoom, (float) pCamera->OrthoZoom,
             (float) pCamera->FarPlane, (float) pCamera->NearPlane);
     }
@@ -1069,10 +1069,11 @@ static FbxVector4 computeLocalScale(FbxNode *pNode, FbxTime pTime = FBXSDK_TIME_
 
 static void ReadNodeHierarchy(
     RawModel &raw, FbxScene *pScene, FbxNode *pNode,
-    const std::string &parentName, const std::string &path)
+    const long parentId, const std::string &path)
 {
+    const FbxUInt64 nodeId = pNode->GetUniqueID();
     const char *nodeName = pNode->GetName();
-    const int  nodeIndex = raw.AddNode(nodeName, parentName.c_str());
+    const int  nodeIndex = raw.AddNode(nodeId, nodeName, parentId);
     RawNode    &node     = raw.GetNode(nodeIndex);
 
     FbxTransform::EInheritType lInheritType;
@@ -1080,12 +1081,12 @@ static void ReadNodeHierarchy(
 
     std::string newPath = path + "/" + nodeName;
     if (verboseOutput) {
-        fmt::printf("node %d: %s\n", nodeIndex, newPath.c_str());
+        fmt::printf("node %d: %s %d\n", nodeIndex, newPath.c_str(), nodeId);
     }
 
     static int warnRrSsCount = 0;
     static int warnRrsCount  = 0;
-    if (lInheritType == FbxTransform::eInheritRrSs && !parentName.empty()) {
+    if (lInheritType == FbxTransform::eInheritRrSs && parentId) {
         if (++warnRrSsCount == 1) {
             fmt::printf("Warning: node %s uses unsupported transform inheritance type 'eInheritRrSs'.\n", newPath);
             fmt::printf("         (Further warnings of this type squelched.)\n");
@@ -1112,19 +1113,19 @@ static void ReadNodeHierarchy(
     node.rotation    = toQuatf(localRotation);
     node.scale       = toVec3f(localScaling);
 
-    if (parentName.size() > 0) {
-        RawNode &parentNode = raw.GetNode(raw.GetNodeByName(parentName.c_str()));
+    if (parentId) {
+        RawNode &parentNode = raw.GetNode(raw.GetNodeById(nodeId));
         // Add unique child name to the parent node.
-        if (std::find(parentNode.childNames.begin(), parentNode.childNames.end(), nodeName) == parentNode.childNames.end()) {
-            parentNode.childNames.push_back(nodeName);
+        if (std::find(parentNode.childIds.begin(), parentNode.childIds.end(), nodeId) == parentNode.childIds.end()) {
+            parentNode.childIds.push_back(nodeId);
         }
     } else {
         // If there is no parent then this is the root node.
-        raw.SetRootNode(nodeName);
+        raw.SetRootNode(nodeId);
     }
 
     for (int child = 0; child < pNode->GetChildCount(); child++) {
-        ReadNodeHierarchy(raw, pScene, pNode->GetChild(child), nodeName, newPath);
+        ReadNodeHierarchy(raw, pScene, pNode->GetChild(child), nodeId, newPath);
     }
 }
 
@@ -1180,7 +1181,7 @@ static void ReadAnimations(RawModel &raw, FbxScene *pScene)
             bool hasMorphs      = false;
 
             RawChannel channel;
-            channel.nodeIndex = raw.GetNodeByName(pNode->GetName());
+            channel.nodeIndex = raw.GetNodeById(pNode->GetUniqueID());
 
             for (FbxLongLong frameIndex = firstFrameIndex; frameIndex <= lastFrameIndex; frameIndex++) {
                 FbxTime pTime;
@@ -1423,7 +1424,7 @@ bool LoadFBXFile(RawModel &raw, const char *fbxFileName, const char *textureExte
         FbxSystemUnit::m.ConvertScene(pScene);
     }
 
-    ReadNodeHierarchy(raw, pScene, pScene->GetRootNode(), "", "");
+    ReadNodeHierarchy(raw, pScene, pScene->GetRootNode(), 0, "");
     ReadNodeAttributes(raw, pScene, pScene->GetRootNode(), textureLocations);
     ReadAnimations(raw, pScene);
 

--- a/src/Fbx2Raw.cpp
+++ b/src/Fbx2Raw.cpp
@@ -724,8 +724,8 @@ static void ReadMesh(RawModel &raw, FbxScene *pScene, FbxNode *pNode, const std:
 
     if (verboseOutput) {
         fmt::printf(
-            "mesh %d: %s (skinned: %d)\n", rawSurfaceIndex, meshName,
-            skinning.IsSkinned() ? skinning.GetRootNode() : 0);
+            "mesh %d: %s (skinned: %s)\n", rawSurfaceIndex, meshName,
+            skinning.IsSkinned() ? raw.GetNode(raw.GetNodeById(skinning.GetRootNode())).name.c_str() : "NO");
     }
 
     // The FbxNode geometric transformation describes how a FbxNodeAttribute is offset from
@@ -1081,7 +1081,7 @@ static void ReadNodeHierarchy(
 
     std::string newPath = path + "/" + nodeName;
     if (verboseOutput) {
-        fmt::printf("node %d: %s %d\n", nodeIndex, newPath.c_str(), nodeId);
+        fmt::printf("node %d: %s\n", nodeIndex, newPath.c_str());
     }
 
     static int warnRrSsCount = 0;

--- a/src/Raw2Gltf.cpp
+++ b/src/Raw2Gltf.cpp
@@ -304,7 +304,7 @@ ModelData *Raw2Gltf(
 
     std::unique_ptr<GLTFData> gltf(new GLTFData(options.outputBinary));
 
-    std::map<long, std::shared_ptr<NodeData>>     nodesById;
+    std::map<long, std::shared_ptr<NodeData>>            nodesById;
     std::map<std::string, std::shared_ptr<MaterialData>> materialsByName;
     std::map<std::string, std::shared_ptr<TextureData>>  textureByIndicesKey;
     std::map<long, std::shared_ptr<MeshData>>            meshBySurfaceId;

--- a/src/RawModel.cpp
+++ b/src/RawModel.cpp
@@ -224,7 +224,7 @@ int RawModel::AddCameraOrthographic(
 {
     RawCamera camera;
     camera.name               = name;
-    camera.nodeId = nodeId;
+    camera.nodeId             = nodeId;
     camera.mode               = RawCamera::CAMERA_MODE_ORTHOGRAPHIC;
     camera.orthographic.magX  = magX;
     camera.orthographic.magY  = magY;

--- a/src/RawModel.cpp
+++ b/src/RawModel.cpp
@@ -193,8 +193,8 @@ int RawModel::AddAnimation(const RawAnimation &animation)
 int RawModel::AddNode(const RawNode &node)
 {
     for (size_t i = 0; i < nodes.size(); i++) {
-        if (Gltf::StringUtils::CompareNoCase(nodes[i].name.c_str(), node.name) == 0) {
-            return (int) i;
+        if (nodes[i].id == node.id) {
+            return (int)i;
         }
     }
 
@@ -203,12 +203,12 @@ int RawModel::AddNode(const RawNode &node)
 }
 
 int RawModel::AddCameraPerspective(
-    const char *name, const char *nodeName, const float aspectRatio, const float fovDegreesX, const float fovDegreesY, const float nearZ,
+    const char *name, const long nodeId, const float aspectRatio, const float fovDegreesX, const float fovDegreesY, const float nearZ,
     const float farZ)
 {
     RawCamera camera;
     camera.name                    = name;
-    camera.nodeName                = nodeName;
+    camera.nodeId                  = nodeId;
     camera.mode                    = RawCamera::CAMERA_MODE_PERSPECTIVE;
     camera.perspective.aspectRatio = aspectRatio;
     camera.perspective.fovDegreesX = fovDegreesX;
@@ -220,11 +220,11 @@ int RawModel::AddCameraPerspective(
 }
 
 int RawModel::AddCameraOrthographic(
-    const char *name, const char *nodeName, const float magX, const float magY, const float nearZ, const float farZ)
+    const char *name, const long nodeId, const float magX, const float magY, const float nearZ, const float farZ)
 {
     RawCamera camera;
     camera.name               = name;
-    camera.nodeName           = nodeName;
+    camera.nodeId = nodeId;
     camera.mode               = RawCamera::CAMERA_MODE_ORTHOGRAPHIC;
     camera.orthographic.magX  = magX;
     camera.orthographic.magY  = magY;
@@ -234,20 +234,21 @@ int RawModel::AddCameraOrthographic(
     return (int) cameras.size() - 1;
 }
 
-int RawModel::AddNode(const char *name, const char *parentName)
+int RawModel::AddNode(const long id, const char *name, const long parentId)
 {
     assert(name[0] != '\0');
 
     for (size_t i = 0; i < nodes.size(); i++) {
-        if (Gltf::StringUtils::CompareNoCase(nodes[i].name, name) == 0) {
+        if (nodes[i].id == id ) {
             return (int) i;
         }
     }
 
     RawNode joint;
     joint.isJoint     = false;
+    joint.id          = id;
     joint.name        = name;
-    joint.parentName  = parentName;
+    joint.parentId    = parentId;
     joint.surfaceId   = 0;
     joint.translation = Vec3f(0, 0, 0);
     joint.rotation    = Quatf(0, 0, 0, 1);
@@ -455,9 +456,9 @@ void RawModel::CreateMaterialModels(
         RawSurface &rawSurface = model->GetSurface(surfaceIndex);
 
         if (model->GetSurfaceCount() > prevSurfaceCount) {
-            const std::vector<std::string> &jointNames = surfaces[sortedTriangles[i].surfaceIndex].jointNames;
-            for (const auto &jointName : jointNames) {
-                const int nodeIndex = GetNodeByName(jointName.c_str());
+            const std::vector<long> &jointIds = surfaces[sortedTriangles[i].surfaceIndex].jointIds;
+            for (const auto &jointId : jointIds) {
+                const int nodeIndex = GetNodeById(jointId);
                 assert(nodeIndex != -1);
                 model->AddNode(GetNode(nodeIndex));
             }
@@ -515,10 +516,10 @@ void RawModel::CreateMaterialModels(
     }
 }
 
-int RawModel::GetNodeByName(const char *name) const
+int RawModel::GetNodeById(const long nodeId) const
 {
     for (size_t i = 0; i < nodes.size(); i++) {
-        if (nodes[i].name == name) {
+        if (nodes[i].id == nodeId) {
             return (int) i;
         }
     }

--- a/src/RawModel.h
+++ b/src/RawModel.h
@@ -277,9 +277,9 @@ struct RawSurface
 {
     long                         id;
     std::string                  name;                            // The name of this surface
-    std::string                  skeletonRootName;                // The name of the root of the skeleton.
+    long                         skeletonRootId;                  // The name of the root of the skeleton.
     Bounds<float, 3>             bounds;
-    std::vector<std::string>     jointNames;
+    std::vector<long>            jointIds;
     std::vector<Vec3f>           jointGeometryMins;
     std::vector<Vec3f>           jointGeometryMaxs;
     std::vector<Mat4f>           inverseBindMatrices;
@@ -306,7 +306,7 @@ struct RawAnimation
 struct RawCamera
 {
     std::string name;
-    std::string nodeName;
+    long        nodeId;
 
     enum
     {
@@ -335,9 +335,10 @@ struct RawCamera
 struct RawNode
 {
     bool                     isJoint;
+    long                     id;
     std::string              name;
-    std::string              parentName;
-    std::vector<std::string> childNames;
+    long                     parentId;
+    std::vector<long>        childIds;
     Vec3f                    translation;
     Quatf                    rotation;
     Vec3f                    scale;
@@ -362,14 +363,14 @@ public:
     int AddSurface(const char *name, long surfaceId);
     int AddAnimation(const RawAnimation &animation);
     int AddCameraPerspective(
-        const char *name, const char *nodeName, const float aspectRatio, const float fovDegreesX, const float fovDegreesY,
+        const char *name, const long nodeId, const float aspectRatio, const float fovDegreesX, const float fovDegreesY,
         const float nearZ, const float farZ);
     int
-    AddCameraOrthographic(const char *name, const char *nodeName, const float magX, const float magY, const float nearZ, const float farZ);
+    AddCameraOrthographic(const char *name, const long nodeId, const float magX, const float magY, const float nearZ, const float farZ);
     int AddNode(const RawNode &node);
-    int AddNode(const char *name, const char *parentName);
-    void SetRootNode(const char *name) { rootNodeName = name; }
-    const char *GetRootNode() const { return rootNodeName.c_str(); }
+    int AddNode(const long id, const char *name, const long parentId);
+    void SetRootNode(const long nodeId) { rootNodeId = nodeId; }
+    const long GetRootNode() const { return rootNodeId; }
 
     // Remove unused vertices, textures or materials after removing vertex attributes, textures, materials or surfaces.
     void Condense();
@@ -413,7 +414,7 @@ public:
     int GetNodeCount() const { return (int) nodes.size(); }
     const RawNode &GetNode(const int index) const { return nodes[index]; }
     RawNode &GetNode(const int index) { return nodes[index]; }
-    int GetNodeByName(const char *name) const;
+    int GetNodeById(const long nodeId) const;
 
     // Create individual attribute arrays.
     // Returns true if the vertices store the particular attribute.
@@ -427,7 +428,7 @@ public:
         std::vector<RawModel> &materialModels, const int maxModelVertices, const int keepAttribs, const bool forceDiscrete) const;
 
 private:
-    std::string                                      rootNodeName;
+    long                                             rootNodeId;
     int                                              vertexAttributes;
     std::unordered_map<RawVertex, int, VertexHasher> vertexHash;
     std::vector<RawVertex>                           vertices;

--- a/src/RawModel.h
+++ b/src/RawModel.h
@@ -277,7 +277,7 @@ struct RawSurface
 {
     long                         id;
     std::string                  name;                            // The name of this surface
-    long                         skeletonRootId;                  // The name of the root of the skeleton.
+    long                         skeletonRootId;                  // The id of the root node of the skeleton.
     Bounds<float, 3>             bounds;
     std::vector<long>            jointIds;
     std::vector<Vec3f>           jointGeometryMins;


### PR DESCRIPTION
This PR fix the problem caused when several nodes has the same name:
https://github.com/facebookincubator/FBX2glTF/issues/41

To fix that issue I've used the FbxNode::GetUniqueID() as node identificator, instead of identify with its node name. Because of that, every node reference that previously was associated to a name string, now is associated to a nodeId (long)

Best regards,
David Ávila, Wave Engine team member
www.waveengine.net
