### PR TITLE
Allow to use fbx model framerate, instead 24 fps

### DIFF
--- a/src/Fbx2Raw.cpp
+++ b/src/Fbx2Raw.cpp
@@ -688,7 +688,7 @@ static void ReadMesh(RawModel &raw, FbxScene *pScene, FbxNode *pNode, const std:
         const std::shared_ptr<FbxMaterialAccess> fbxMaterial = materials.GetMaterial(polygonIndex);
 
         int textures[RAW_TEXTURE_USAGE_MAX];
-        std::fill_n(textures, RAW_TEXTURE_USAGE_MAX, -1);
+        std::fill_n(textures, (int)RAW_TEXTURE_USAGE_MAX, -1);
 
         FbxString  shadingModel, materialName;
         FbxVector4 ambient, specular, diffuse, emissive;
@@ -1005,9 +1005,10 @@ static void ReadNodeHierarchy(
     }
 }
 
-static void ReadAnimations(RawModel &raw, FbxScene *pScene)
+static void ReadAnimations(RawModel &raw, FbxScene *pScene, const bool useModelFramerate)
 {
-    FbxTime::EMode eMode = FbxTime::eFrames24;
+    FbxTime::EMode eMode = useModelFramerate ? pScene->GetGlobalSettings().GetTimeMode() : FbxTime::eFrames24;
+    
     const double epsilon = 1e-5f;
 
     const int animationCount = pScene->GetSrcObjectCount<FbxAnimStack>();
@@ -1261,7 +1262,7 @@ FindFbxTextures(
     }
 }
 
-bool LoadFBXFile(RawModel &raw, const char *fbxFileName, const char *textureExtensions)
+bool LoadFBXFile(RawModel &raw, const char *fbxFileName, const char *textureExtensions, const bool useModelFramerate)
 {
     FbxManager    *pManager    = FbxManager::Create();
     FbxIOSettings *pIoSettings = FbxIOSettings::Create(pManager, IOSROOT);
@@ -1302,7 +1303,7 @@ bool LoadFBXFile(RawModel &raw, const char *fbxFileName, const char *textureExte
 
     ReadNodeHierarchy(raw, pScene, pScene->GetRootNode(), "", "");
     ReadNodeAttributes(raw, pScene, pScene->GetRootNode(), textureLocations);
-    ReadAnimations(raw, pScene);
+    ReadAnimations(raw, pScene, useModelFramerate);
 
     pScene->Destroy();
     pManager->Destroy();

--- a/src/Fbx2Raw.h
+++ b/src/Fbx2Raw.h
@@ -12,6 +12,6 @@
 
 #include "RawModel.h"
 
-bool LoadFBXFile(RawModel &raw, const char *fbxFileName, const char *textureExtensions);
+bool LoadFBXFile(RawModel &raw, const char *fbxFileName, const char *textureExtensions, const bool useModelFramerate);
 
 #endif // !__FBX2RAW_H__

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,6 +39,7 @@ int main(int argc, char *argv[])
 
     std::string inputPath;
     std::string outputPath;
+    bool useModelFramerate = false;
 
     std::vector<std::function<Vec2f(Vec2f)>> texturesTransforms;
 
@@ -71,6 +72,9 @@ int main(int argc, char *argv[])
                (
                    "d,draco", "Apply Draco mesh compression to geometries.",
                    cxxopts::value<bool>(gltfOptions.useDraco))
+               (
+                   "model-framerate", "Use the framerate of FBX model to sample animation keyframes.",
+                   cxxopts::value<bool>(useModelFramerate))
                ("flip-u", "Flip all U texture coordinates.")
                ("flip-v", "Flip all V texture coordinates (default behaviour!)")
                ("no-flip-v", "Suppress the default flipping of V texture coordinates")
@@ -197,7 +201,7 @@ Copyright (c) 2016-2017 Oculus VR, LLC.
     if (verboseOutput) {
         fmt::printf("Loading FBX File: %s\n", inputPath);
     }
-    if (!LoadFBXFile(raw, inputPath.c_str(), "png;jpg;jpeg")) {
+    if (!LoadFBXFile(raw, inputPath.c_str(), "png;jpg;jpeg", useModelFramerate)) {
         fmt::fprintf(stderr, "ERROR:: Failed to parse FBX: %s\n", inputPath);
         return 1;
     }


### PR DESCRIPTION
By default FBX2glTF sample the animations with 24fps.

This PR allows to use the framerate specified in the fbx scene. I've created the "--model-framerate" command line argument to enable that feature.

Best regards,
David Ávila,
WaveEngine team member