### PR TITLE
Fix camera rotation from FBX, fix illegal memory access of binary data

### DIFF
--- a/src/FBX2glTF.cpp
+++ b/src/FBX2glTF.cpp
@@ -293,15 +293,18 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    const unsigned char *binaryData = &(*data_render_model->binary)[0];
-    unsigned long       binarySize  = data_render_model->binary->size();
-    if (fwrite(binaryData, binarySize, 1, fp) != 1) {
-        fmt::fprintf(stderr, "ERROR: Failed to write %lu bytes to file '%s'.\n", binarySize, binaryPath);
+    if (data_render_model->binary->empty() == false)
+    {
+        const unsigned char *binaryData = &(*data_render_model->binary)[0];
+        unsigned long       binarySize  = data_render_model->binary->size();
+        if (fwrite(binaryData, binarySize, 1, fp) != 1) {
+            fmt::fprintf(stderr, "ERROR: Failed to write %lu bytes to file '%s'.\n", binarySize, binaryPath);
+            fclose(fp);
+            return 1;
+        }
         fclose(fp);
-        return 1;
+        fmt::printf("Wrote %lu bytes of binary data to %s.\n", binarySize, binaryPath);
     }
-    fclose(fp);
-    fmt::printf("Wrote %lu bytes of binary data to %s.\n", binarySize, binaryPath);
 
     delete data_render_model;
     return 0;

--- a/src/fbx/Fbx2Raw.cpp
+++ b/src/fbx/Fbx2Raw.cpp
@@ -381,6 +381,14 @@ static void ReadCamera(RawModel &raw, FbxScene *pScene, FbxNode *pNode)
             (float) pCamera->OrthoZoom, (float) pCamera->OrthoZoom,
             (float) pCamera->FarPlane, (float) pCamera->NearPlane);
     }
+
+    // Cameras in FBX coordinate space face +X when rotation is (0,0,0)
+    // We need to adjust this to face glTF specified -Z
+    auto nodeIdx = raw.GetNodeById(pNode->GetUniqueID());
+    auto& rawNode = raw.GetNode(nodeIdx);
+
+    auto r = Quatf::FromAngleAxis(-90 * ((float) M_PI / 180.0f), {0.0, 1.0, 0.0});
+    rawNode.rotation = rawNode.rotation * r;
 }
 
 static void ReadNodeProperty(RawModel &raw, FbxNode *pNode, FbxProperty &prop)


### PR DESCRIPTION
More information found here.
I tested that this commit zeroes out rotation correctly when exporting a zero transform camera from Maya.

https://forums.autodesk.com/t5/fbx-forum/90-postrotation-of-camera-and-light-nodes/m-p/4225298/highlight/true#M8467