### PR TITLE
fix fov computation from fbxsdk

### DIFF
--- a/src/fbx/Fbx2Raw.cpp
+++ b/src/fbx/Fbx2Raw.cpp
@@ -415,6 +415,10 @@ static void ReadCamera(RawModel &raw, FbxScene *pScene, FbxNode *pNode)
             fovy = HFOV2VFOV(fovx, apertureRatio);
             break;
         }
+        default: {
+            fmt::printf("Warning:: Unsupported ApertureMode. Setting FOV to 0.\n");
+            break;
+        }
     }
 
     if (pCamera->ProjectionType.Get() == FbxCamera::EProjectionType::ePerspective) {


### PR DESCRIPTION
Need to do some fun checks of fbx internal camera model before computing FOV.

Useful FBXSDK example if we want to support more camera info later.
https://help.autodesk.com/view/FBX/2017/ENU/?guid=__cpp_ref__view_scene_2_set_camera_8cxx_example_html