### PR TITLE
Fix skinning weight normalization. 

### DIFF
--- a/src/fbx/FbxSkinningAccess.cpp
+++ b/src/fbx/FbxSkinningAccess.cpp
@@ -75,7 +75,8 @@ FbxSkinningAccess::FbxSkinningAccess(const FbxMesh* pMesh, FbxScene* pScene, Fbx
         }
       }
       for (int i = 0; i < controlPointCount; i++) {
-        vertexJointWeights[i] = vertexJointWeights[i].Normalized();
+        const float weightSumRcp = 1.0 / (vertexJointWeights[i][0] + vertexJointWeights[i][1] + vertexJointWeights[i][2] + vertexJointWeights[i][3]);
+        vertexJointWeights[i] *= weightSumRcp;
       }
     }
   }


### PR DESCRIPTION
Previous code would call Normalized() on a Vec4f containing the skinning weights. This normalizes the vector, i.e. makes the length of the vector equal to 1.0. For skinning weights what we want is the sum of the weights to be 1.0, which is a different. This commit fixes that.