### PR TITLE
Dockerize FBX2glTF

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.dockerignore
+Dockerfile
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,12 @@ FROM ubuntu:16.04
 RUN apt-get update && \
     apt-get install -y software-properties-common && \
     add-apt-repository ppa:jonathonf/python-3.6 && \
+    add-apt-repository ppa:git-core/ppa && \
     apt-get update && \
     apt-get install -y python3.6 curl build-essential cmake libxml2-dev zlib1g-dev git && \
+    curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && \
+    apt-get install -y git-lfs && \
+    git lfs install && \
     curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py && \
     pip install conan && \
     conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan
@@ -12,15 +16,15 @@ RUN apt-get update && \
 # Install FBX SDK
 WORKDIR /fbxsdktemp
 
-RUN curl -L https://www.autodesk.com/content/dam/autodesk/www/adn/fbx/20192/fbx20192_fbxsdk_linux.tar.gz -o fbx20192_fbxsdk_linux.tar.gz && \
-	tar -xvf fbx20192_fbxsdk_linux.tar.gz && \
-	echo "yes\nn" | ./fbx20192_fbxsdk_linux /usr && \
-	rm -rf /fbxsdktemp
-
 COPY . /fbx2gltf
 
 WORKDIR /fbx2gltf
 
-RUN conan install . -i build -s build_type=Release -e FBXSDK_SDKS=sdk && \
-    conan build -bf build .
+RUN git lfs pull
 
+# Build and install
+RUN conan install . -i build -s build_type=Release -e FBXSDK_SDKS=/fbx2gltf/sdk && \
+    conan build -bf build . && \
+    cp build/FBX2glTF /usr/bin && \
+    cd / && \
+    rm -rf /fbx2gltf

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ COPY . /fbx2gltf
 
 WORKDIR /fbx2gltf
 
+# Pull the fbx sdk
 RUN git lfs pull
 
 # Build and install

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,6 @@ RUN apt-get update && \
     add-apt-repository ppa:git-core/ppa && \
     apt-get update && \
     apt-get install -y python3.6 curl build-essential cmake libxml2-dev zlib1g-dev git && \
-    curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && \
-    apt-get install -y git-lfs && \
-    git lfs install && \
     curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py && \
     pip install conan && \
     conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan
@@ -17,8 +14,11 @@ COPY . /fbx2gltf
 
 WORKDIR /fbx2gltf
 
-# Pull the fbx sdk
-RUN git lfs pull
+# Install FBX SDK
+RUN curl -L https://www.autodesk.com/content/dam/autodesk/www/adn/fbx/20192/fbx20192_fbxsdk_linux.tar.gz -o fbx20192_fbxsdk_linux.tar.gz && \
+	tar -xvf fbx20192_fbxsdk_linux.tar.gz && \
+	echo "yes\nn" | ./fbx20192_fbxsdk_linux /fbx2gltf/sdk/Linux/2019.2 && \
+	rm -rf /fbxsdktemp
 
 # Build and install
 RUN conan install . -i build -s build_type=Release -e FBXSDK_SDKS=/fbx2gltf/sdk && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,6 @@ RUN apt-get update && \
     pip install conan && \
     conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan
 
-# Install FBX SDK
-WORKDIR /fbxsdktemp
-
 COPY . /fbx2gltf
 
 WORKDIR /fbx2gltf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && \
+    apt-get install -y software-properties-common && \
+    add-apt-repository ppa:jonathonf/python-3.6 && \
+    apt-get update && \
+    apt-get install -y python3.6 curl build-essential cmake libxml2-dev zlib1g-dev git && \
+    curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py && \
+    pip install conan && \
+    conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan
+
+# Install FBX SDK
+WORKDIR /fbxsdktemp
+
+RUN curl -L https://www.autodesk.com/content/dam/autodesk/www/adn/fbx/20192/fbx20192_fbxsdk_linux.tar.gz -o fbx20192_fbxsdk_linux.tar.gz && \
+	tar -xvf fbx20192_fbxsdk_linux.tar.gz && \
+	echo "yes\nn" | ./fbx20192_fbxsdk_linux /usr && \
+	rm -rf /fbxsdktemp
+
+COPY . /fbx2gltf
+
+WORKDIR /fbx2gltf
+
+RUN conan install . -i build -s build_type=Release -e FBXSDK_SDKS=sdk && \
+    conan build -bf build .
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,5 @@
+version: '3.7'
+services:
+  fbx2gltf:
+    build:
+      context: .


### PR DESCRIPTION
This pull request dockerizes FBX2glTF and is based on the azure build file. I've included a simple `docker-compose.yaml` because I find its syntax more convenient. A few notes

* To build an image run `docker-compose build`.
* To run in the container run `docker-compose run fbx2gltf bash`. `FBX2glTF` is on the PATH, so it can be executed from anywhere.
* I attempted to use git lfs to fetch the FBX SDK, but it caused problems in managed build environments such as Docker Hub and Google Cloud Build. Instead, the Dockerfile fetches the SDK directly from Autodesk
* If this pull request is accepted, it'd be great to setup automatic builds on Docker Hub.
---

I am still finding that the latest build segfaults, but that appears to match the current build on azure. Related #183