### PR TITLE
Tell AppVeyor to install the FBX SDK from elsewhere

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,11 @@ stack: python %PYTHON%
 cache:
   - C:\Users\appveyor\.conan\data -> appveyor.yml
 
+init:
+  - git config --global filter.lfs.required false
+  - git config --global filter.lfs.smudge "git-lfs smudge --skip %f"
+  - git config --global filter.lfs.process "git-lfs filter-process --skip"
+
 install:
   - cinst zstandard
   - ps: Start-FileDownload 'https://github.com/zellski/FBXSDK-Windows/archive/2019.2.tar.gz'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ install:
   - ps: Start-FileDownload 'https://github.com/zellski/FBXSDK-Windows/archive/2019.2.tar.gz'
   - 7z e 2019.2.tar.gz
   - 7z x 2019.2.tar
-  - ps: move -v .\FBXSDK-Windows\sdk\ .
+  - ps: move -v .\FBXSDK-Windows-2019.2\sdk\ .
   - ps: zstd -d -r --rm sdk
   - cmd: echo "Downloading conan..."
   - cmd: set PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,12 @@ cache:
   - C:\Users\appveyor\.conan\data -> appveyor.yml
 
 install:
+  - cinst zstandard
+  - ps: Start-FileDownload 'https://github.com/zellski/FBXSDK-Windows/archive/2019.2.tar.gz'
+  - 7z e 2019.2.tar.gz
+  - 7z x 2019.2.tar
+  - ps: move -v .\FBXSDK-Windows\sdk\ .
+  - ps: zstd -d -r --rm sdk
   - cmd: echo "Downloading conan..."
   - cmd: set PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
   - cmd: python --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
 stack: python %PYTHON%
 
 cache:
-  - C:\Users\appveyor\.conan\data -> appveyor.yml
+  - C:\Users\appveyor\.conan\data -> appveyor.yml, conanfile.py
 
 init:
   - git config --global filter.lfs.required false


### PR DESCRIPTION
This is just the Windows equivalent of https://github.com/facebookincubator/FBX2glTF/pull/200.
