### PR TITLE
Add support for arbitrary number of skinning weights. 

### DIFF
--- a/src/FBX2glTF.cpp
+++ b/src/FBX2glTF.cpp
@@ -140,10 +140,11 @@ int main(int argc, char* argv[]) {
       gltfOptions.useBlendShapeTangents,
       "Include blend shape tangents, if reported present by the FBX SDK.");
 
-  app.add_flag(
+  app.add_option(
       "--normalize-weights",
       gltfOptions.normalizeSkinningWeights,
-      "Normalize skinning weights.");
+      "Normalize skinning weights.",
+      true);
 
   app.add_option(
       "--skinning-weights",
@@ -156,8 +157,7 @@ int main(int argc, char* argv[]) {
          "-k,--keep-attribute",
          [&](std::vector<std::string> attributes) -> bool {
            gltfOptions.keepAttribs =
-             RAW_VERTEX_ATTRIBUTE_JOINT_INDICES0 | RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS0 | RAW_VERTEX_ATTRIBUTE_JOINT_INDICES1 | RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS1 |
-             RAW_VERTEX_ATTRIBUTE_JOINT_INDICES2 | RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS2 | RAW_VERTEX_ATTRIBUTE_JOINT_INDICES3 | RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS3;
+             RAW_VERTEX_ATTRIBUTE_JOINT_INDICES | RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS;
            for (std::string attribute : attributes) {
              if (attribute == "position") {
                gltfOptions.keepAttribs |= RAW_VERTEX_ATTRIBUTE_POSITION;

--- a/src/FBX2glTF.cpp
+++ b/src/FBX2glTF.cpp
@@ -144,7 +144,7 @@ int main(int argc, char* argv[]) {
          "-k,--keep-attribute",
          [&](std::vector<std::string> attributes) -> bool {
            gltfOptions.keepAttribs =
-               RAW_VERTEX_ATTRIBUTE_JOINT_INDICES | RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS;
+             RAW_VERTEX_ATTRIBUTE_JOINT_INDICES0 | RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS0 | RAW_VERTEX_ATTRIBUTE_JOINT_INDICES1 | RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS1;
            for (std::string attribute : attributes) {
              if (attribute == "position") {
                gltfOptions.keepAttribs |= RAW_VERTEX_ATTRIBUTE_POSITION;

--- a/src/FBX2glTF.cpp
+++ b/src/FBX2glTF.cpp
@@ -140,11 +140,24 @@ int main(int argc, char* argv[]) {
       gltfOptions.useBlendShapeTangents,
       "Include blend shape tangents, if reported present by the FBX SDK.");
 
+  app.add_flag(
+      "--normalize-weights",
+      gltfOptions.normalizeSkinningWeights,
+      "Normalize skinning weights.");
+
+  app.add_option(
+      "--skinning-weights",
+      gltfOptions.maxSkinningWeights,
+      "How many joint influences per vertex are allowed.",
+      true)
+      ->check(CLI::Range(1, RawModel::MAX_SUPPORTED_WEIGHTS));
+
   app.add_option(
          "-k,--keep-attribute",
          [&](std::vector<std::string> attributes) -> bool {
            gltfOptions.keepAttribs =
-             RAW_VERTEX_ATTRIBUTE_JOINT_INDICES0 | RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS0 | RAW_VERTEX_ATTRIBUTE_JOINT_INDICES1 | RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS1;
+             RAW_VERTEX_ATTRIBUTE_JOINT_INDICES0 | RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS0 | RAW_VERTEX_ATTRIBUTE_JOINT_INDICES1 | RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS1 |
+             RAW_VERTEX_ATTRIBUTE_JOINT_INDICES2 | RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS2 | RAW_VERTEX_ATTRIBUTE_JOINT_INDICES3 | RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS3;
            for (std::string attribute : attributes) {
              if (attribute == "position") {
                gltfOptions.keepAttribs |= RAW_VERTEX_ATTRIBUTE_POSITION;
@@ -204,7 +217,7 @@ int main(int argc, char* argv[]) {
   app.add_option(
          "--draco-bits-for-normals",
          gltfOptions.draco.quantBitsNormal,
-         "How many bits to quantize nornals to.",
+         "How many bits to quantize normals to.",
          true)
       ->check(CLI::Range(1, 32))
       ->group("Draco");
@@ -310,7 +323,7 @@ int main(int argc, char* argv[]) {
   if (!texturesTransforms.empty()) {
     raw.TransformTextures(texturesTransforms);
   }
-  raw.Condense();
+  raw.Condense(gltfOptions.maxSkinningWeights, gltfOptions.normalizeSkinningWeights);
   raw.TransformGeometry(gltfOptions.computeNormals);
 
   std::ofstream outStream; // note: auto-flushes in destructor

--- a/src/FBX2glTF.cpp
+++ b/src/FBX2glTF.cpp
@@ -151,7 +151,7 @@ int main(int argc, char* argv[]) {
       gltfOptions.maxSkinningWeights,
       "How many joint influences per vertex are allowed.",
       true)
-      ->check(CLI::Range(1, RawModel::MAX_SUPPORTED_WEIGHTS));
+      ->check(CLI::Range(0, 512));
 
   app.add_option(
          "-k,--keep-attribute",

--- a/src/FBX2glTF.h
+++ b/src/FBX2glTF.h
@@ -99,6 +99,10 @@ struct GltfOptions
     bool useBlendShapeNormals { false };
     /** Whether to include blend shape tangents, if present according to the SDK. */
     bool useBlendShapeTangents { false };
+    /** Whether to normalized skinning weights. */
+    bool normalizeSkinningWeights { true };
+    /** Maximum number of bone influences per vertex. */
+    int maxSkinningWeights { 4 };
     /** When to compute vertex normals from geometry. */
     ComputeNormalsOption computeNormals = ComputeNormalsOption::BROKEN;
     /** When to use 32-bit indices. */

--- a/src/fbx/FbxSkinningAccess.cpp
+++ b/src/fbx/FbxSkinningAccess.cpp
@@ -20,8 +20,7 @@ FbxSkinningAccess::FbxSkinningAccess(const FbxMesh* pMesh, FbxScene* pScene, Fbx
         continue;
       }
       int controlPointCount = pMesh->GetControlPointsCount();
-      vertexJointIndices.resize(controlPointCount);
-      vertexJointWeights.resize(controlPointCount);
+      vertexSkinning.resize(controlPointCount);
 
       for (int clusterIndex = 0; clusterIndex < clusterCount; clusterIndex++) {
         FbxCluster* cluster = skin->GetCluster(clusterIndex);
@@ -55,33 +54,18 @@ FbxSkinningAccess::FbxSkinningAccess(const FbxMesh* pMesh, FbxScene* pScene, Fbx
           if (clusterIndices[i] < 0 || clusterIndices[i] >= controlPointCount) {
             continue;
           }
-          if (clusterWeights[i] <= 0.0 || vertexJointWeights[clusterIndices[i]].size() >= MAX_WEIGHTS) {
+          if (clusterWeights[i] <= 0.0) {
             continue;
           }
-          vertexJointIndices[clusterIndices[i]].push_back(clusterIndex);
-          vertexJointWeights[clusterIndices[i]].push_back((float)clusterWeights[i]);
-          for (int j = vertexJointWeights[clusterIndices[i]].size() - 1; j > 0; j--) {
-            if (vertexJointWeights[clusterIndices[i]][j - 1] >=
-                vertexJointWeights[clusterIndices[i]][j]) {
-              break;
-            }
-            std::swap(
-                vertexJointIndices[clusterIndices[i]][j - 1],
-                vertexJointIndices[clusterIndices[i]][j]);
-            std::swap(
-                vertexJointWeights[clusterIndices[i]][j - 1],
-                vertexJointWeights[clusterIndices[i]][j]);
-          }
+
+          vertexSkinning[clusterIndices[i]].push_back(FbxVertexSkinningInfo{(int) clusterIndex, (float)clusterWeights[i]});
+
         }
       }
-      for (int i = 0; i < controlPointCount; i++) {
-        float weightSum = 0.0;
-        for (int w = 0; w < vertexJointWeights[i].size(); ++w)
-          weightSum += vertexJointWeights[i][w];
-        float weightSumRcp = 1.0 / weightSum;
-        for (int w = 0; w < vertexJointWeights[i].size(); ++w)
-          vertexJointWeights[i][w] *= weightSumRcp;
-      }
+      
+      for (int i = 0; i < vertexSkinning.size(); i++)
+        maxBoneInfluences = std::max((int) vertexSkinning[i].size(), maxBoneInfluences);
+
     }
   }
 

--- a/src/fbx/FbxSkinningAccess.cpp
+++ b/src/fbx/FbxSkinningAccess.cpp
@@ -75,7 +75,8 @@ FbxSkinningAccess::FbxSkinningAccess(const FbxMesh* pMesh, FbxScene* pScene, Fbx
         }
       }
       for (int i = 0; i < controlPointCount; i++) {
-        vertexJointWeights[i] = vertexJointWeights[i].Normalized();
+        const float weightSumRcp = 1.0 / (vertexJointWeights[i][0] + vertexJointWeights[i][1] + vertexJointWeights[i][2] + vertexJointWeights[i][3]);
+        vertexJointWeights[i] *= weightSumRcp;
       }
     }
   }

--- a/src/fbx/FbxSkinningAccess.hpp
+++ b/src/fbx/FbxSkinningAccess.hpp
@@ -19,19 +19,21 @@
 
 #include "FBX2glTF.h"
 
+struct FbxVertexSkinningInfo {
+  int jointId;
+  float weight;
+};
+
+
 class FbxSkinningAccess {
  public:
-  static const int MAX_WEIGHTS = 8;
 
   FbxSkinningAccess(const FbxMesh* pMesh, FbxScene* pScene, FbxNode* pNode);
 
   bool IsSkinned() const {
-    return (vertexJointWeights.size() > 0);
+    return (vertexSkinning.size() > 0);
   }
 
-  int MaxWeights() const {
-    return MAX_WEIGHTS;
-  }
 
   int GetNodeCount() const {
     return (int)jointNodes.size();
@@ -62,31 +64,17 @@ class FbxSkinningAccess {
     return inverseBindMatrices[jointIndex];
   }
 
-  const Vec4i GetVertexIndices(const int controlPointIndex, const int subset) const {
-    if (vertexJointIndices.empty())
-      return Vec4i(0, 0, 0, 0);
-    Vec4i indices(0, 0, 0, 0);
-    for (int k = subset * 4; k < subset * 4 + 4 && k < vertexJointIndices[controlPointIndex].size(); k++)
-      indices[k - subset * 4] = vertexJointIndices[controlPointIndex][k];
-    return indices;
-  }
-
-  const Vec4f GetVertexWeights(const int controlPointIndex, const int subset) const {
-    if (vertexJointWeights.empty())
-      return Vec4f(0.0f);
-    Vec4f weights(0.0f);
-    for (int k = subset * 4; k < subset * 4 + 4 && k < vertexJointWeights[controlPointIndex].size(); k++)
-      weights[k - subset * 4] = vertexJointWeights[controlPointIndex][k];
-    return weights;
+  const std::vector<FbxVertexSkinningInfo> GetVertexSkinningInfo(const int controlPointIndex) const {
+    return vertexSkinning[controlPointIndex];
   }
 
  private:
   int rootIndex;
+  int maxBoneInfluences;
   std::vector<long> jointIds;
   std::vector<FbxNode*> jointNodes;
   std::vector<FbxMatrix> jointSkinningTransforms;
   std::vector<FbxMatrix> jointInverseGlobalTransforms;
   std::vector<FbxAMatrix> inverseBindMatrices;
-  std::vector<std::vector<uint16_t>> vertexJointIndices;
-  std::vector<std::vector<float>> vertexJointWeights;
+  std::vector<std::vector<FbxVertexSkinningInfo>> vertexSkinning;
 };

--- a/src/fbx/FbxSkinningAccess.hpp
+++ b/src/fbx/FbxSkinningAccess.hpp
@@ -21,12 +21,16 @@
 
 class FbxSkinningAccess {
  public:
-  static const int MAX_WEIGHTS = 4;
+  static const int MAX_WEIGHTS = 8;
 
   FbxSkinningAccess(const FbxMesh* pMesh, FbxScene* pScene, FbxNode* pNode);
 
   bool IsSkinned() const {
     return (vertexJointWeights.size() > 0);
+  }
+
+  int MaxWeights() const {
+    return MAX_WEIGHTS;
   }
 
   int GetNodeCount() const {
@@ -58,14 +62,22 @@ class FbxSkinningAccess {
     return inverseBindMatrices[jointIndex];
   }
 
-  const Vec4i GetVertexIndices(const int controlPointIndex) const {
-    return (!vertexJointIndices.empty()) ? vertexJointIndices[controlPointIndex]
-                                         : Vec4i(0, 0, 0, 0);
+  const Vec4i GetVertexIndices(const int controlPointIndex, const int subset) const {
+    if (vertexJointIndices.empty())
+      return Vec4i(0, 0, 0, 0);
+    Vec4i indices(0, 0, 0, 0);
+    for (int k = subset * 4; k < subset * 4 + 4 && k < vertexJointIndices[controlPointIndex].size(); k++)
+      indices[k - subset * 4] = vertexJointIndices[controlPointIndex][k];
+    return indices;
   }
 
-  const Vec4f GetVertexWeights(const int controlPointIndex) const {
-    return (!vertexJointWeights.empty()) ? vertexJointWeights[controlPointIndex]
-                                         : Vec4f(0, 0, 0, 0);
+  const Vec4f GetVertexWeights(const int controlPointIndex, const int subset) const {
+    if (vertexJointWeights.empty())
+      return Vec4f(0.0f);
+    Vec4f weights(0.0f);
+    for (int k = subset * 4; k < subset * 4 + 4 && k < vertexJointWeights[controlPointIndex].size(); k++)
+      weights[k - subset * 4] = vertexJointWeights[controlPointIndex][k];
+    return weights;
   }
 
  private:
@@ -75,6 +87,6 @@ class FbxSkinningAccess {
   std::vector<FbxMatrix> jointSkinningTransforms;
   std::vector<FbxMatrix> jointInverseGlobalTransforms;
   std::vector<FbxAMatrix> inverseBindMatrices;
-  std::vector<Vec4i> vertexJointIndices;
-  std::vector<Vec4f> vertexJointWeights;
+  std::vector<std::vector<uint16_t>> vertexJointIndices;
+  std::vector<std::vector<float>> vertexJointWeights;
 };

--- a/src/gltf/GltfModel.hpp
+++ b/src/gltf/GltfModel.hpp
@@ -124,38 +124,6 @@ class GltfModel {
   };
 
   template <class T>
-  std::shared_ptr<AccessorData> AddArrayAttributeToPrimitive(
-    BufferData& buffer,
-    const RawModel& surfaceModel,
-    PrimitiveData& primitive,
-    const AttributeDefinition<T>& attrDef) {
-    // copy attribute data into vector
-    std::vector<std::vector<T>> attribArr;
-    surfaceModel.GetAttributeArray<T>(attribArr, attrDef.rawAttributeIx);
-
-    const AttributeDefinition<Vec4f> ATTR_WEIGHTS(
-      "WEIGHTS_0",
-      &RawVertex::jointWeights,
-      attrDef.glType,
-      attrDef.dracoAttribute,
-      draco::DT_FLOAT32);
-
-    std::shared_ptr<AccessorData> accessor;
-    if (attrDef.dracoComponentType != draco::DT_INVALID && primitive.dracoMesh != nullptr) {
-      primitive.AddDracoAttrib(attrDef, attribArr);
-
-      accessor = accessors.hold(new AccessorData(attrDef.glType));
-      accessor->count = attribArr.size();
-    }
-    else {
-      auto bufferView = GetAlignedBufferView(buffer, BufferViewData::GL_ARRAY_BUFFER);
-      accessor = AddAccessorWithView(*bufferView, attrDef.glType, attribArr, std::string(""));
-    }
-    primitive.AddAttrib(attrDef.gltfName, *accessor);
-    return accessor;
-  };
-
-  template <class T>
   void serializeHolder(json& glTFJson, std::string key, const Holder<T> holder) {
     if (!holder.ptrs.empty()) {
       std::vector<json> bits;

--- a/src/gltf/GltfModel.hpp
+++ b/src/gltf/GltfModel.hpp
@@ -124,6 +124,31 @@ class GltfModel {
   };
 
   template <class T>
+  std::shared_ptr<AccessorData> AddAttributeArrayToPrimitive(
+    BufferData& buffer,
+    const RawModel& surfaceModel,
+    PrimitiveData& primitive,
+    const AttributeArrayDefinition<T>& attrDef) {
+    // copy attribute data into vector
+    std::vector<T> attribArr;
+    surfaceModel.GetArrayAttributeArray<T>(attribArr, attrDef.rawAttributeIx, attrDef.arrayOffset);
+
+    std::shared_ptr<AccessorData> accessor;
+    if (attrDef.dracoComponentType != draco::DT_INVALID && primitive.dracoMesh != nullptr) {
+      primitive.AddDracoArrayAttrib(attrDef, attribArr);
+
+      accessor = accessors.hold(new AccessorData(attrDef.glType));
+      accessor->count = attribArr.size();
+    }
+    else {
+      auto bufferView = GetAlignedBufferView(buffer, BufferViewData::GL_ARRAY_BUFFER);
+      accessor = AddAccessorWithView(*bufferView, attrDef.glType, attribArr, std::string(""));
+    }
+    primitive.AddAttrib(attrDef.gltfName, *accessor);
+    return accessor;
+  };
+
+  template <class T>
   void serializeHolder(json& glTFJson, std::string key, const Holder<T> holder) {
     if (!holder.ptrs.empty()) {
       std::vector<json> bits;

--- a/src/gltf/Raw2Gltf.cpp
+++ b/src/gltf/Raw2Gltf.cpp
@@ -532,22 +532,40 @@ ModelData* Raw2Gltf(
               draco::DT_FLOAT32);
           gltf->AddAttributeToPrimitive<Vec2f>(buffer, surfaceModel, *primitive, ATTR_TEXCOORD_1);
         }
-        if ((surfaceModel.GetVertexAttributes() & RAW_VERTEX_ATTRIBUTE_JOINT_INDICES) != 0) {
+        if ((surfaceModel.GetVertexAttributes() & RAW_VERTEX_ATTRIBUTE_JOINT_INDICES0) != 0) {
           const AttributeDefinition<Vec4i> ATTR_JOINTS(
               "JOINTS_0",
-              &RawVertex::jointIndices,
+              &RawVertex::jointIndices0,
               GLT_VEC4I,
               draco::GeometryAttribute::GENERIC,
               draco::DT_UINT16);
           gltf->AddAttributeToPrimitive<Vec4i>(buffer, surfaceModel, *primitive, ATTR_JOINTS);
         }
-        if ((surfaceModel.GetVertexAttributes() & RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS) != 0) {
+        if ((surfaceModel.GetVertexAttributes() & RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS0) != 0) {
           const AttributeDefinition<Vec4f> ATTR_WEIGHTS(
               "WEIGHTS_0",
-              &RawVertex::jointWeights,
+              &RawVertex::jointWeights0,
               GLT_VEC4F,
               draco::GeometryAttribute::GENERIC,
               draco::DT_FLOAT32);
+          gltf->AddAttributeToPrimitive<Vec4f>(buffer, surfaceModel, *primitive, ATTR_WEIGHTS);
+        }
+        if ((surfaceModel.GetVertexAttributes() & RAW_VERTEX_ATTRIBUTE_JOINT_INDICES1) != 0) {
+          const AttributeDefinition<Vec4i> ATTR_JOINTS(
+            "JOINTS_1",
+            &RawVertex::jointIndices1,
+            GLT_VEC4I,
+            draco::GeometryAttribute::GENERIC,
+            draco::DT_UINT16);
+          gltf->AddAttributeToPrimitive<Vec4i>(buffer, surfaceModel, *primitive, ATTR_JOINTS);
+        }
+        if ((surfaceModel.GetVertexAttributes() & RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS1) != 0) {
+          const AttributeDefinition<Vec4f> ATTR_WEIGHTS(
+            "WEIGHTS_1",
+            &RawVertex::jointWeights1,
+            GLT_VEC4F,
+            draco::GeometryAttribute::GENERIC,
+            draco::DT_FLOAT32);
           gltf->AddAttributeToPrimitive<Vec4f>(buffer, surfaceModel, *primitive, ATTR_WEIGHTS);
         }
 

--- a/src/gltf/Raw2Gltf.cpp
+++ b/src/gltf/Raw2Gltf.cpp
@@ -532,77 +532,31 @@ ModelData* Raw2Gltf(
               draco::DT_FLOAT32);
           gltf->AddAttributeToPrimitive<Vec2f>(buffer, surfaceModel, *primitive, ATTR_TEXCOORD_1);
         }
-        if ((surfaceModel.GetVertexAttributes() & RAW_VERTEX_ATTRIBUTE_JOINT_INDICES0) != 0) {
-          const AttributeDefinition<Vec4i> ATTR_JOINTS(
-              "JOINTS_0",
-              &RawVertex::jointIndices0,
+        if ((surfaceModel.GetVertexAttributes() & RAW_VERTEX_ATTRIBUTE_JOINT_INDICES) != 0) {
+          for (int i = 0; i < surfaceModel.GetGlobalWeightCount(); i += 4) {
+            const AttributeArrayDefinition<Vec4i> ATTR_JOINTS(
+              std::string("JOINTS_") + std::to_string(i/4),
+              //"JOINTS_0",
+              &RawVertex::jointIndices,
               GLT_VEC4I,
               draco::GeometryAttribute::GENERIC,
-              draco::DT_UINT16);
-          gltf->AddAttributeToPrimitive<Vec4i>(buffer, surfaceModel, *primitive, ATTR_JOINTS);
+              draco::DT_UINT16,
+              i/4);
+            gltf->AddAttributeArrayToPrimitive<Vec4i>(buffer, surfaceModel, *primitive, ATTR_JOINTS);
+          }
         }
-        if ((surfaceModel.GetVertexAttributes() & RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS0) != 0) {
-          const AttributeDefinition<Vec4f> ATTR_WEIGHTS(
-              "WEIGHTS_0",
-              &RawVertex::jointWeights0,
+        if ((surfaceModel.GetVertexAttributes() & RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS) != 0) {
+          for (int i = 0; i < surfaceModel.GetGlobalWeightCount(); i += 4) {
+            const AttributeArrayDefinition<Vec4f> ATTR_WEIGHTS(
+              std::string("WEIGHTS_") + std::to_string(i/4),
+              //"WEIGHTS_0",
+              &RawVertex::jointWeights,
               GLT_VEC4F,
               draco::GeometryAttribute::GENERIC,
-              draco::DT_FLOAT32);
-          gltf->AddAttributeToPrimitive<Vec4f>(buffer, surfaceModel, *primitive, ATTR_WEIGHTS);
-        }
-        if ((surfaceModel.GetVertexAttributes() & RAW_VERTEX_ATTRIBUTE_JOINT_INDICES1) != 0) {
-          const AttributeDefinition<Vec4i> ATTR_JOINTS(
-            "JOINTS_1",
-            &RawVertex::jointIndices1,
-            GLT_VEC4I,
-            draco::GeometryAttribute::GENERIC,
-            draco::DT_UINT16);
-          gltf->AddAttributeToPrimitive<Vec4i>(buffer, surfaceModel, *primitive, ATTR_JOINTS);
-        }
-        if ((surfaceModel.GetVertexAttributes() & RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS1) != 0) {
-          const AttributeDefinition<Vec4f> ATTR_WEIGHTS(
-            "WEIGHTS_1",
-            &RawVertex::jointWeights1,
-            GLT_VEC4F,
-            draco::GeometryAttribute::GENERIC,
-            draco::DT_FLOAT32);
-          gltf->AddAttributeToPrimitive<Vec4f>(buffer, surfaceModel, *primitive, ATTR_WEIGHTS);
-        }
-        if ((surfaceModel.GetVertexAttributes() & RAW_VERTEX_ATTRIBUTE_JOINT_INDICES2) != 0) {
-          const AttributeDefinition<Vec4i> ATTR_JOINTS(
-            "JOINTS_0",
-            &RawVertex::jointIndices2,
-            GLT_VEC4I,
-            draco::GeometryAttribute::GENERIC,
-            draco::DT_UINT16);
-          gltf->AddAttributeToPrimitive<Vec4i>(buffer, surfaceModel, *primitive, ATTR_JOINTS);
-        }
-        if ((surfaceModel.GetVertexAttributes() & RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS2) != 0) {
-          const AttributeDefinition<Vec4f> ATTR_WEIGHTS(
-            "WEIGHTS_0",
-            &RawVertex::jointWeights2,
-            GLT_VEC4F,
-            draco::GeometryAttribute::GENERIC,
-            draco::DT_FLOAT32);
-          gltf->AddAttributeToPrimitive<Vec4f>(buffer, surfaceModel, *primitive, ATTR_WEIGHTS);
-        }
-        if ((surfaceModel.GetVertexAttributes() & RAW_VERTEX_ATTRIBUTE_JOINT_INDICES3) != 0) {
-          const AttributeDefinition<Vec4i> ATTR_JOINTS(
-            "JOINTS_0",
-            &RawVertex::jointIndices3,
-            GLT_VEC4I,
-            draco::GeometryAttribute::GENERIC,
-            draco::DT_UINT16);
-          gltf->AddAttributeToPrimitive<Vec4i>(buffer, surfaceModel, *primitive, ATTR_JOINTS);
-        }
-        if ((surfaceModel.GetVertexAttributes() & RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS3) != 0) {
-          const AttributeDefinition<Vec4f> ATTR_WEIGHTS(
-            "WEIGHTS_0",
-            &RawVertex::jointWeights3,
-            GLT_VEC4F,
-            draco::GeometryAttribute::GENERIC,
-            draco::DT_FLOAT32);
-          gltf->AddAttributeToPrimitive<Vec4f>(buffer, surfaceModel, *primitive, ATTR_WEIGHTS);
+              draco::DT_FLOAT32,
+              i/4);
+            gltf->AddAttributeArrayToPrimitive<Vec4f>(buffer, surfaceModel, *primitive, ATTR_WEIGHTS);
+          }
         }
 
         // each channel present in the mesh always ends up a target in the primitive

--- a/src/gltf/Raw2Gltf.cpp
+++ b/src/gltf/Raw2Gltf.cpp
@@ -536,7 +536,6 @@ ModelData* Raw2Gltf(
           for (int i = 0; i < surfaceModel.GetGlobalWeightCount(); i += 4) {
             const AttributeArrayDefinition<Vec4i> ATTR_JOINTS(
               std::string("JOINTS_") + std::to_string(i/4),
-              //"JOINTS_0",
               &RawVertex::jointIndices,
               GLT_VEC4I,
               draco::GeometryAttribute::GENERIC,
@@ -549,7 +548,6 @@ ModelData* Raw2Gltf(
           for (int i = 0; i < surfaceModel.GetGlobalWeightCount(); i += 4) {
             const AttributeArrayDefinition<Vec4f> ATTR_WEIGHTS(
               std::string("WEIGHTS_") + std::to_string(i/4),
-              //"WEIGHTS_0",
               &RawVertex::jointWeights,
               GLT_VEC4F,
               draco::GeometryAttribute::GENERIC,

--- a/src/gltf/Raw2Gltf.cpp
+++ b/src/gltf/Raw2Gltf.cpp
@@ -568,6 +568,42 @@ ModelData* Raw2Gltf(
             draco::DT_FLOAT32);
           gltf->AddAttributeToPrimitive<Vec4f>(buffer, surfaceModel, *primitive, ATTR_WEIGHTS);
         }
+        if ((surfaceModel.GetVertexAttributes() & RAW_VERTEX_ATTRIBUTE_JOINT_INDICES2) != 0) {
+          const AttributeDefinition<Vec4i> ATTR_JOINTS(
+            "JOINTS_0",
+            &RawVertex::jointIndices2,
+            GLT_VEC4I,
+            draco::GeometryAttribute::GENERIC,
+            draco::DT_UINT16);
+          gltf->AddAttributeToPrimitive<Vec4i>(buffer, surfaceModel, *primitive, ATTR_JOINTS);
+        }
+        if ((surfaceModel.GetVertexAttributes() & RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS2) != 0) {
+          const AttributeDefinition<Vec4f> ATTR_WEIGHTS(
+            "WEIGHTS_0",
+            &RawVertex::jointWeights2,
+            GLT_VEC4F,
+            draco::GeometryAttribute::GENERIC,
+            draco::DT_FLOAT32);
+          gltf->AddAttributeToPrimitive<Vec4f>(buffer, surfaceModel, *primitive, ATTR_WEIGHTS);
+        }
+        if ((surfaceModel.GetVertexAttributes() & RAW_VERTEX_ATTRIBUTE_JOINT_INDICES3) != 0) {
+          const AttributeDefinition<Vec4i> ATTR_JOINTS(
+            "JOINTS_0",
+            &RawVertex::jointIndices3,
+            GLT_VEC4I,
+            draco::GeometryAttribute::GENERIC,
+            draco::DT_UINT16);
+          gltf->AddAttributeToPrimitive<Vec4i>(buffer, surfaceModel, *primitive, ATTR_JOINTS);
+        }
+        if ((surfaceModel.GetVertexAttributes() & RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS3) != 0) {
+          const AttributeDefinition<Vec4f> ATTR_WEIGHTS(
+            "WEIGHTS_0",
+            &RawVertex::jointWeights3,
+            GLT_VEC4F,
+            draco::GeometryAttribute::GENERIC,
+            draco::DT_FLOAT32);
+          gltf->AddAttributeToPrimitive<Vec4f>(buffer, surfaceModel, *primitive, ATTR_WEIGHTS);
+        }
 
         // each channel present in the mesh always ends up a target in the primitive
         for (int channelIx = 0; channelIx < rawSurface.blendChannels.size(); channelIx++) {

--- a/src/gltf/Raw2Gltf.hpp
+++ b/src/gltf/Raw2Gltf.hpp
@@ -173,7 +173,7 @@ struct AttributeDefinition {
 template <class T>
 struct AttributeArrayDefinition {
   const std::string gltfName;
-  const T (RawVertex::*rawAttributeIx)[(RawModel::MAX_SUPPORTED_WEIGHTS -1 ) / 4 + 1];
+  const std::vector<T> RawVertex::*rawAttributeIx;
   const GLType glType;
   const int arrayOffset;
   const draco::GeometryAttribute::Type dracoAttribute;
@@ -181,7 +181,7 @@ struct AttributeArrayDefinition {
 
   AttributeArrayDefinition(
     const std::string gltfName,
-    const T (RawVertex::*rawAttributeIx)[(RawModel::MAX_SUPPORTED_WEIGHTS - 1) / 4 + 1],
+    const std::vector<T> RawVertex::*rawAttributeIx,
     const GLType& _glType,
     const draco::GeometryAttribute::Type dracoAttribute,
     const draco::DataType dracoComponentType,

--- a/src/gltf/Raw2Gltf.hpp
+++ b/src/gltf/Raw2Gltf.hpp
@@ -154,6 +154,44 @@ struct AttributeDefinition {
         glType(_glType),
         dracoAttribute(draco::GeometryAttribute::INVALID),
         dracoComponentType(draco::DataType::DT_INVALID) {}
+
+  AttributeDefinition(
+    const std::string gltfName,
+    const T RawVertex::*rawAttributeIx,
+    const GLType& _glType,
+    const draco::GeometryAttribute::Type dracoAttribute,
+    const draco::DataType dracoComponentType,
+    const int arrayOffset)
+    : gltfName(gltfName),
+    rawAttributeIx(rawAttributeIx),
+    glType(_glType),
+    dracoAttribute(dracoAttribute),
+    dracoComponentType(dracoComponentType),
+    arrayOffset(arrayOffset){}
+};
+
+template <class T>
+struct AttributeArrayDefinition {
+  const std::string gltfName;
+  const T (RawVertex::*rawAttributeIx)[(RawModel::MAX_SUPPORTED_WEIGHTS -1 ) / 4 + 1];
+  const GLType glType;
+  const int arrayOffset;
+  const draco::GeometryAttribute::Type dracoAttribute;
+  const draco::DataType dracoComponentType;
+
+  AttributeArrayDefinition(
+    const std::string gltfName,
+    const T (RawVertex::*rawAttributeIx)[(RawModel::MAX_SUPPORTED_WEIGHTS - 1) / 4 + 1],
+    const GLType& _glType,
+    const draco::GeometryAttribute::Type dracoAttribute,
+    const draco::DataType dracoComponentType,
+    const int arrayOffset)
+    : gltfName(gltfName),
+    rawAttributeIx(rawAttributeIx),
+    glType(_glType),
+    dracoAttribute(dracoAttribute),
+    dracoComponentType(dracoComponentType),
+    arrayOffset(arrayOffset) {}
 };
 
 struct AccessorData;

--- a/src/gltf/properties/PrimitiveData.hpp
+++ b/src/gltf/properties/PrimitiveData.hpp
@@ -62,6 +62,32 @@ struct PrimitiveData {
     dracoAttributes[attribute.gltfName] = dracoAttId;
   }
 
+  template <class T>
+  void AddDracoArrayAttrib(const AttributeArrayDefinition<T> attribute, const std::vector<T>& attribArr) {
+    draco::PointAttribute att;
+    int8_t componentCount = attribute.glType.count;
+    att.Init(
+      attribute.dracoAttribute,
+      nullptr,
+      componentCount,
+      attribute.dracoComponentType,
+      false,
+      componentCount * draco::DataTypeLength(attribute.dracoComponentType),
+      0);
+
+    const int dracoAttId = dracoMesh->AddAttribute(att, true, attribArr.size());
+    draco::PointAttribute* attPtr = dracoMesh->attribute(dracoAttId);
+
+    std::vector<uint8_t> buf(sizeof(T));
+    for (uint32_t ii = 0; ii < attribArr.size(); ii++) {
+      uint8_t* ptr = &buf[0];
+      attribute.glType.write(ptr, attribArr[ii]);
+      attPtr->SetAttributeValue(attPtr->mapped_index(draco::PointIndex(ii)), ptr);
+    }
+
+    dracoAttributes[attribute.gltfName] = dracoAttId;
+  }
+
   void NoteDracoBuffer(const BufferViewData& data);
 
   const int indices;

--- a/src/raw/RawModel.cpp
+++ b/src/raw/RawModel.cpp
@@ -26,9 +26,12 @@
 bool RawVertex::operator==(const RawVertex& other) const {
   return (position == other.position) && (normal == other.normal) && (tangent == other.tangent) &&
       (binormal == other.binormal) && (color == other.color) && (uv0 == other.uv0) &&
-      (uv1 == other.uv1) && (jointIndices0 == other.jointIndices0) &&
-      (jointWeights0 == other.jointWeights0) && (jointIndices1 == other.jointIndices1) &&
-      (jointWeights1 == other.jointWeights1) && (polarityUv0 == other.polarityUv0) &&
+      (uv1 == other.uv1) &&
+      (jointWeights0 == other.jointWeights0) && (jointWeights1 == other.jointWeights1) &&
+      (jointWeights2 == other.jointWeights2) && (jointWeights3 == other.jointWeights3) &&
+      (jointIndices0 == other.jointIndices0) && (jointIndices1 == other.jointIndices1) &&
+      (jointIndices2 == other.jointIndices2) && (jointIndices3 == other.jointIndices3) &&
+      (polarityUv0 == other.polarityUv0) &&
       (blendSurfaceIx == other.blendSurfaceIx) && (blends == other.blends);
 }
 

--- a/src/raw/RawModel.cpp
+++ b/src/raw/RawModel.cpp
@@ -26,8 +26,9 @@
 bool RawVertex::operator==(const RawVertex& other) const {
   return (position == other.position) && (normal == other.normal) && (tangent == other.tangent) &&
       (binormal == other.binormal) && (color == other.color) && (uv0 == other.uv0) &&
-      (uv1 == other.uv1) && (jointIndices == other.jointIndices) &&
-      (jointWeights == other.jointWeights) && (polarityUv0 == other.polarityUv0) &&
+      (uv1 == other.uv1) && (jointIndices0 == other.jointIndices0) &&
+      (jointWeights0 == other.jointWeights0) && (jointIndices1 == other.jointIndices1) &&
+      (jointWeights1 == other.jointWeights1) && (polarityUv0 == other.polarityUv0) &&
       (blendSurfaceIx == other.blendSurfaceIx) && (blends == other.blends);
 }
 
@@ -55,11 +56,17 @@ size_t RawVertex::Difference(const RawVertex& other) const {
     attributes |= RAW_VERTEX_ATTRIBUTE_UV1;
   }
   // Always need both or neither.
-  if (jointIndices != other.jointIndices) {
-    attributes |= RAW_VERTEX_ATTRIBUTE_JOINT_INDICES | RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS;
+  if (jointIndices0 != other.jointIndices0) {
+    attributes |= RAW_VERTEX_ATTRIBUTE_JOINT_INDICES0 | RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS0;
   }
-  if (jointWeights != other.jointWeights) {
-    attributes |= RAW_VERTEX_ATTRIBUTE_JOINT_INDICES | RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS;
+  if (jointWeights0 != other.jointWeights0) {
+    attributes |= RAW_VERTEX_ATTRIBUTE_JOINT_INDICES0 | RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS0;
+  }
+  if (jointIndices1 != other.jointIndices1) {
+    attributes |= RAW_VERTEX_ATTRIBUTE_JOINT_INDICES1 | RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS1;
+  }
+  if (jointWeights1 != other.jointWeights1) {
+    attributes |= RAW_VERTEX_ATTRIBUTE_JOINT_INDICES1 | RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS1;
   }
   return attributes;
 }
@@ -573,7 +580,7 @@ void RawModel::CreateMaterialModels(
       if (keepAttribs != -1) {
         int keep = keepAttribs;
         if ((keepAttribs & RAW_VERTEX_ATTRIBUTE_POSITION) != 0) {
-          keep |= RAW_VERTEX_ATTRIBUTE_JOINT_INDICES | RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS;
+          keep |= RAW_VERTEX_ATTRIBUTE_JOINT_INDICES0 | RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS0 | RAW_VERTEX_ATTRIBUTE_JOINT_INDICES1 | RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS1;
         }
         if ((keepAttribs & RAW_VERTEX_ATTRIBUTE_AUTO) != 0) {
           keep |= RAW_VERTEX_ATTRIBUTE_POSITION;
@@ -614,11 +621,17 @@ void RawModel::CreateMaterialModels(
         if ((keep & RAW_VERTEX_ATTRIBUTE_UV1) == 0) {
           vertex.uv1 = defaultVertex.uv1;
         }
-        if ((keep & RAW_VERTEX_ATTRIBUTE_JOINT_INDICES) == 0) {
-          vertex.jointIndices = defaultVertex.jointIndices;
+        if ((keep & RAW_VERTEX_ATTRIBUTE_JOINT_INDICES0) == 0) {
+          vertex.jointIndices0 = defaultVertex.jointIndices0;
         }
-        if ((keep & RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS) == 0) {
-          vertex.jointWeights = defaultVertex.jointWeights;
+        if ((keep & RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS0) == 0) {
+          vertex.jointWeights0 = defaultVertex.jointWeights0;
+        }
+        if ((keep & RAW_VERTEX_ATTRIBUTE_JOINT_INDICES1) == 0) {
+          vertex.jointIndices1 = defaultVertex.jointIndices1;
+        }
+        if ((keep & RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS1) == 0) {
+          vertex.jointWeights1 = defaultVertex.jointWeights1;
         }
       }
 

--- a/src/raw/RawModel.hpp
+++ b/src/raw/RawModel.hpp
@@ -15,8 +15,6 @@
 
 #include "FBX2glTF.h"
 
-#define MAX_SKINNING_WEIGHTS 32
-
 enum RawVertexAttribute {
   RAW_VERTEX_ATTRIBUTE_POSITION = 1 << 0,
   RAW_VERTEX_ATTRIBUTE_NORMAL = 1 << 1,
@@ -61,8 +59,8 @@ struct RawVertex {
   Vec4f color{0.0f};
   Vec2f uv0{0.0f};
   Vec2f uv1{0.0f};
-  Vec4i jointIndices[(MAX_SKINNING_WEIGHTS - 1) / 4 + 1];
-  Vec4f jointWeights[(MAX_SKINNING_WEIGHTS - 1) / 4 + 1];
+  std::vector<Vec4i> jointIndices;
+  std::vector<Vec4f> jointWeights;
 
 
   std::vector<RawVertexSkinningInfo> skinningInfo;
@@ -372,7 +370,6 @@ struct RawNode {
 
 class RawModel {
  public:
-  static const int MAX_SUPPORTED_WEIGHTS = MAX_SKINNING_WEIGHTS;
 
   RawModel();
 
@@ -542,7 +539,7 @@ class RawModel {
   // Returns true if the vertices store the particular attribute.
   template <typename _attrib_type_>
   void GetArrayAttributeArray(std::vector<_attrib_type_>& out, 
-    const _attrib_type_ (RawVertex::*ptr)[(RawModel::MAX_SUPPORTED_WEIGHTS - 1) / 4 + 1],
+    const std::vector<_attrib_type_> RawVertex::*ptr,
     const int arrayOffset)
     const;
 
@@ -586,7 +583,7 @@ void RawModel::GetAttributeArray(
 template <typename _attrib_type_>
 void RawModel::GetArrayAttributeArray(
   std::vector<_attrib_type_>& out,
-  const _attrib_type_ (RawVertex::*ptr)[(RawModel::MAX_SUPPORTED_WEIGHTS - 1) / 4 + 1],
+  const std::vector<_attrib_type_> RawVertex::*ptr,
   const int arrayOffset) const {
   out.resize(vertices.size());
   for (size_t i = 0; i < vertices.size(); i++) {

--- a/src/raw/RawModel.hpp
+++ b/src/raw/RawModel.hpp
@@ -23,8 +23,10 @@ enum RawVertexAttribute {
   RAW_VERTEX_ATTRIBUTE_COLOR = 1 << 4,
   RAW_VERTEX_ATTRIBUTE_UV0 = 1 << 5,
   RAW_VERTEX_ATTRIBUTE_UV1 = 1 << 6,
-  RAW_VERTEX_ATTRIBUTE_JOINT_INDICES = 1 << 7,
-  RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS = 1 << 8,
+  RAW_VERTEX_ATTRIBUTE_JOINT_INDICES0 = 1 << 7,
+  RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS0 = 1 << 8,
+  RAW_VERTEX_ATTRIBUTE_JOINT_INDICES1 = 1 << 9,
+  RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS1 = 1 << 10,
 
   RAW_VERTEX_ATTRIBUTE_AUTO = 1 << 31
 };
@@ -49,8 +51,10 @@ struct RawVertex {
   Vec4f color{0.0f};
   Vec2f uv0{0.0f};
   Vec2f uv1{0.0f};
-  Vec4i jointIndices{0, 0, 0, 0};
-  Vec4f jointWeights{0.0f};
+  Vec4i jointIndices0{0,0,0,0};
+  Vec4i jointIndices1{0,0,0,0};
+  Vec4f jointWeights0{0.0f};
+  Vec4f jointWeights1{0.0f};
   // end of members that directly correspond to vertex attributes
 
   // if this vertex participates in a blend shape setup, the surfaceIx of its dedicated mesh;

--- a/src/raw/RawModel.hpp
+++ b/src/raw/RawModel.hpp
@@ -27,6 +27,10 @@ enum RawVertexAttribute {
   RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS0 = 1 << 8,
   RAW_VERTEX_ATTRIBUTE_JOINT_INDICES1 = 1 << 9,
   RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS1 = 1 << 10,
+  RAW_VERTEX_ATTRIBUTE_JOINT_INDICES2 = 1 << 11,
+  RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS2 = 1 << 12,
+  RAW_VERTEX_ATTRIBUTE_JOINT_INDICES3 = 1 << 13,
+  RAW_VERTEX_ATTRIBUTE_JOINT_WEIGHTS3 = 1 << 14,
 
   RAW_VERTEX_ATTRIBUTE_AUTO = 1 << 31
 };
@@ -38,6 +42,16 @@ struct RawBlendVertex {
 
   bool operator==(const RawBlendVertex& other) const {
     return position == other.position && normal == other.normal && tangent == other.tangent;
+  }
+};
+
+struct RawVertexSkinningInfo
+{
+  int jointIndex;
+  float jointWeight;
+
+  bool operator>(const RawVertexSkinningInfo& rjw) const {
+    return jointWeight > rjw.jointWeight;
   }
 };
 
@@ -53,8 +67,14 @@ struct RawVertex {
   Vec2f uv1{0.0f};
   Vec4i jointIndices0{0,0,0,0};
   Vec4i jointIndices1{0,0,0,0};
+  Vec4i jointIndices2{0,0,0,0};
+  Vec4i jointIndices3{0,0,0,0};
   Vec4f jointWeights0{0.0f};
   Vec4f jointWeights1{0.0f};
+  Vec4f jointWeights2{0.0f};
+  Vec4f jointWeights3{0.0f};
+
+  std::vector<RawVertexSkinningInfo> skinningInfo;
   // end of members that directly correspond to vertex attributes
 
   // if this vertex participates in a blend shape setup, the surfaceIx of its dedicated mesh;
@@ -361,6 +381,8 @@ struct RawNode {
 
 class RawModel {
  public:
+  static const int MAX_SUPPORTED_WEIGHTS = 16;
+
   RawModel();
 
   // Add geometry.
@@ -421,7 +443,7 @@ class RawModel {
 
   // Remove unused vertices, textures or materials after removing vertex attributes, textures,
   // materials or surfaces.
-  void Condense();
+  void Condense(const int maxSkinningWeights, const bool normalizeWeights);
 
   void TransformGeometry(ComputeNormalsOption);
 


### PR DESCRIPTION
This change allows for an arbitrary number skinning weights per vertex. 
The number of weights allowed is controlled by the command line parameter --skinning-weights. 
This defaults to 4 so as to not change the current behavior. 
Normalization now also has a command line parameter --normalize-weights which also defaults to the current behavior of normalizing.

The entire pipeline has been upgraded to be agnostic to the number of weights per vertex. The Vec4 structures are populated at the end. Any remainder of weight/index space in the Vec4 structures are zeroed, again as the previous behavior. The code also determines the minimum set of Vec4s are globally for the mesh, and the command line parameter so as to not bloat with all zero structures. All vertices have the same number of Vec4s in the end, which I believe is what the spec requires.