### PR TITLE
Fix iconv on mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,13 @@ find_package(boost_optional MODULE REQUIRED)
 find_package(libxml2 MODULE REQUIRED)
 find_package(zlib MODULE REQUIRED)
 find_package(fmt MODULE REQUIRED)
-find_package(libiconv MODULE REQUIRED)
+
+if (APPLE)
+   find_package(Iconv MODULE REQUIRED)
+else()
+   find_package(libiconv MODULE REQUIRED)
+   add_library(Iconv ALIAS libiconv::libiconv)
+endif()
 
 # create a compilation database for e.g. clang-tidy
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -210,7 +216,7 @@ target_link_libraries(libFBX2glTF
   fmt::fmt
   libxml2::libxml2
   zlib::zlib
-  libiconv::libiconv
+  Iconv
   ${CMAKE_DL_LIBS}
   ${CMAKE_THREAD_LIBS_INIT}
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,13 +51,6 @@ find_package(libxml2 MODULE REQUIRED)
 find_package(zlib MODULE REQUIRED)
 find_package(fmt MODULE REQUIRED)
 
-if (APPLE)
-   find_package(Iconv MODULE REQUIRED)
-else()
-   find_package(libiconv MODULE REQUIRED)
-   add_library(Iconv ALIAS libiconv::libiconv)
-endif()
-
 # create a compilation database for e.g. clang-tidy
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
@@ -216,10 +209,17 @@ target_link_libraries(libFBX2glTF
   fmt::fmt
   libxml2::libxml2
   zlib::zlib
-  Iconv
   ${CMAKE_DL_LIBS}
   ${CMAKE_THREAD_LIBS_INIT}
 )
+
+if (APPLE)
+ find_package(Iconv MODULE REQUIRED)
+ target_link_libraries(libFBX2glTF Iconv)
+else()
+ find_package(libiconv MODULE REQUIRED)
+ target_link_libraries(libFBX2glTF libiconv::libiconv)
+endif()
 
 target_include_directories(libFBX2glTF PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}/src


### PR DESCRIPTION
The FBX SDK is compiled against a regular libiconv on Windows on Linux (with symbols libconv_open() etc) but on Mac, they compiled it against Apple's modified libiconv, which renames those functions. Annoyingly this means we need to explicitly decline the Conan libiconv package, for that platform only.