### PR TITLE
Support Double Sided Material

### DIFF
--- a/src/fbx/Fbx2Raw.cpp
+++ b/src/fbx/Fbx2Raw.cpp
@@ -459,7 +459,7 @@ static void ReadMesh(
     const RawMaterialType materialType =
         GetMaterialType(raw, textures, vertexTransparency, skinning.IsSkinned());
     const int rawMaterialIndex = raw.AddMaterial(
-        materialId, materialName, materialType, textures, rawMatProps, userProperties);
+        materialId, materialName, materialType, textures, rawMatProps, userProperties, false );
 
     raw.AddTriangle(
         rawVertexIndices[0],

--- a/src/gltf/Raw2Gltf.cpp
+++ b/src/gltf/Raw2Gltf.cpp
@@ -392,9 +392,12 @@ ModelData* Raw2Gltf(
         occlusionTexture = simpleTex(RAW_TEXTURE_USAGE_OCCLUSION).get();
       }
 
+      // Setting DoubleSided
+      const bool isDoubleSided = material.isDoubleSided;
       std::shared_ptr<MaterialData> mData = gltf->materials.hold(new MaterialData(
           material.name,
           isTransparent,
+          isDoubleSided,
           material.info->shadingModel,
           normalTexture,
           occlusionTexture,

--- a/src/gltf/properties/MaterialData.cpp
+++ b/src/gltf/properties/MaterialData.cpp
@@ -73,6 +73,7 @@ void to_json(json& j, const PBRMetallicRoughness& d) {
 MaterialData::MaterialData(
     std::string name,
     bool isTransparent,
+    bool isDoubleSided,
     const RawShadingModel shadingModel,
     const TextureData* normalTexture,
     const TextureData* occlusionTexture,
@@ -84,6 +85,7 @@ MaterialData::MaterialData(
       name(std::move(name)),
       shadingModel(shadingModel),
       isTransparent(isTransparent),
+      isDoubleSided(isDoubleSided),
       normalTexture(Tex::ref(normalTexture)),
       occlusionTexture(Tex::ref(occlusionTexture)),
       emissiveTexture(Tex::ref(emissiveTexture)),
@@ -94,6 +96,7 @@ MaterialData::MaterialData(
 json MaterialData::serialize() const {
   json result = {{"name", name},
                  {"alphaMode", isTransparent ? "BLEND" : "OPAQUE"},
+                 {"doubleSided", isDoubleSided},
                  {"extras",
                   {{"fromFBX",
                     {{"shadingModel", Describe(shadingModel)},

--- a/src/gltf/properties/MaterialData.hpp
+++ b/src/gltf/properties/MaterialData.hpp
@@ -43,6 +43,7 @@ struct MaterialData : Holdable {
   MaterialData(
       std::string name,
       bool isTransparent,
+      bool isDoubleSided,
       RawShadingModel shadingModel,
       const TextureData* normalTexture,
       const TextureData* occlusionTexture,
@@ -56,6 +57,7 @@ struct MaterialData : Holdable {
   const std::string name;
   const RawShadingModel shadingModel;
   const bool isTransparent;
+  const bool isDoubleSided;
   const std::unique_ptr<const Tex> normalTexture;
   const std::unique_ptr<const Tex> occlusionTexture;
   const std::unique_ptr<const Tex> emissiveTexture;

--- a/src/raw/RawModel.cpp
+++ b/src/raw/RawModel.cpp
@@ -142,7 +142,8 @@ int RawModel::AddMaterial(const RawMaterial& material) {
       material.type,
       material.textures,
       material.info,
-      material.userProperties);
+      material.userProperties,
+      material.isDoubleSided);
 }
 
 int RawModel::AddMaterial(
@@ -151,7 +152,8 @@ int RawModel::AddMaterial(
     const RawMaterialType materialType,
     const int textures[RAW_TEXTURE_USAGE_MAX],
     std::shared_ptr<RawMatProps> materialInfo,
-    const std::vector<std::string>& userProperties) {
+    const std::vector<std::string>& userProperties,
+    const bool isDoubleSided ) {
   for (size_t i = 0; i < materials.size(); i++) {
     if (materials[i].name != name) {
       continue;
@@ -184,6 +186,7 @@ int RawModel::AddMaterial(
   material.type = materialType;
   material.info = materialInfo;
   material.userProperties = userProperties;
+  material.isDoubleSided = isDoubleSided;
 
   for (int i = 0; i < RAW_TEXTURE_USAGE_MAX; i++) {
     material.textures[i] = textures[i];

--- a/src/raw/RawModel.hpp
+++ b/src/raw/RawModel.hpp
@@ -258,6 +258,7 @@ struct RawMaterial {
   std::shared_ptr<RawMatProps> info;
   int textures[RAW_TEXTURE_USAGE_MAX];
   std::vector<std::string> userProperties;
+  bool isDoubleSided;
 };
 
 enum RawLightType {
@@ -370,7 +371,8 @@ class RawModel {
       const RawMaterialType materialType,
       const int textures[RAW_TEXTURE_USAGE_MAX],
       std::shared_ptr<RawMatProps> materialInfo,
-      const std::vector<std::string>& userProperties);
+      const std::vector<std::string>& userProperties,
+      const bool isDoubleSided );
   int AddLight(
       const char* name,
       RawLightType lightType,


### PR DESCRIPTION
The material has the "isDoubleSided" bool parameter. Because some models have double-sided texture settings, the new bool parameter is added to determine whether Gltf 'doubleSided' is enabled. The default value of this parameter is false.