### PR TITLE
Blendshape name output to mesh.extras.targetNames

### DIFF
--- a/src/gltf/properties/MeshData.cpp
+++ b/src/gltf/properties/MeshData.cpp
@@ -14,12 +14,21 @@ MeshData::MeshData(const std::string& name, const std::vector<float>& weights)
 
 json MeshData::serialize() const {
   json jsonPrimitivesArray = json::array();
+  json targetNames = json::array();
   for (const auto& primitive : primitives) {
     jsonPrimitivesArray.push_back(*primitive);
+    if (!primitive->targetNames.empty()) {
+      for (auto targetName : primitive->targetNames) {
+        targetNames.push_back(targetName);
+      }
+    }
   }
   json result = {{"name", name}, {"primitives", jsonPrimitivesArray}};
   if (!weights.empty()) {
     result["weights"] = weights;
+  }
+  if (!targetNames.empty()) {
+    result["extras"]["targetNames"] = targetNames;
   }
   return result;
 }

--- a/src/gltf/properties/PrimitiveData.cpp
+++ b/src/gltf/properties/PrimitiveData.cpp
@@ -45,6 +45,7 @@ void PrimitiveData::AddTarget(
       positions->ix,
       normals != nullptr ? normals->ix : -1,
       tangents != nullptr ? tangents->ix : -1));
+  targetNames.push_back(positions->name);
 }
 
 void to_json(json& j, const PrimitiveData& d) {

--- a/src/gltf/properties/PrimitiveData.hpp
+++ b/src/gltf/properties/PrimitiveData.hpp
@@ -68,6 +68,7 @@ struct PrimitiveData {
   const MeshMode mode;
 
   std::vector<std::tuple<int, int, int>> targetAccessors{};
+  std::vector<std::string> targetNames{};
 
   std::map<std::string, int> attributes;
   std::map<std::string, int> dracoAttributes;


### PR DESCRIPTION
Hopefully a very basic change to start with, modified the morph target names to output to mesh.extras.targetNames as noted in the discussion here;
https://github.com/KhronosGroup/glTF/issues/1036

... and the consequent implementation note here;
https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#morph-targets
