### PR TITLE
Added support for sparse accessors in blendshapes

### DIFF
--- a/src/FBX2glTF.cpp
+++ b/src/FBX2glTF.cpp
@@ -143,6 +143,11 @@ int main(int argc, char* argv[]) {
       "Transcribe FBX User Properties into glTF node and material 'extras'.");
 
   app.add_flag(
+      "--blend-shape-sparse",
+      gltfOptions.enableSparseBlendShapes,
+      "Use sparse accessors to store blend shapes");
+
+  app.add_flag(
       "--blend-shape-normals",
       gltfOptions.useBlendShapeNormals,
       "Include blend shape normals, if reported present by the FBX SDK.");

--- a/src/FBX2glTF.h
+++ b/src/FBX2glTF.h
@@ -112,6 +112,8 @@ struct GltfOptions {
   /** Whether to include lights through the KHR_punctual_lights extension. */
   bool useKHRLightsPunctual{true};
 
+  /** Whether to use sparse accessors in blend shapes */
+  bool enableSparseBlendShapes{false};
   /** Whether to include blend shape normals, if present according to the SDK. */
   bool useBlendShapeNormals{false};
   /** Whether to include blend shape tangents, if present according to the SDK. */

--- a/src/gltf/GltfModel.hpp
+++ b/src/gltf/GltfModel.hpp
@@ -70,14 +70,38 @@ class GltfModel {
       const std::string& filename);
 
   template <class T>
+  void CopyToBufferView(
+      BufferViewData& bufferView,
+      const std::vector<T>& source,
+      const GLType& type) {
+        bufferView.appendAsBinaryArray(source, *binary, type);
+      }
+
+  template <class T>
   std::shared_ptr<AccessorData> AddAccessorWithView(
       BufferViewData& bufferView,
       const GLType& type,
       const std::vector<T>& source,
       std::string name) {
     auto accessor = accessors.hold(new AccessorData(bufferView, type, name));
-    accessor->appendAsBinaryArray(source, *binary);
-    bufferView.byteLength = accessor->byteLength();
+    bufferView.appendAsBinaryArray(source, *binary, type);
+    accessor->count = bufferView.count;
+    return accessor;
+  }
+
+  template <class T>
+  std::shared_ptr<AccessorData> AddSparseAccessorWithView(
+      AccessorData& baseAccessor,
+      BufferViewData& indexBufferView,
+      const GLType& indexBufferViewType,
+      BufferViewData& bufferView,
+      const GLType& type,
+      const std::vector<T>& source,
+      std::string name) {
+    auto accessor = accessors.hold(new AccessorData(baseAccessor, indexBufferView, bufferView, type, name));
+    bufferView.appendAsBinaryArray(source, *binary, type);
+    accessor->count = baseAccessor.count;
+    accessor->sparseIdxBufferViewType = indexBufferViewType.componentType.glType;
     return accessor;
   }
 

--- a/src/gltf/properties/AccessorData.cpp
+++ b/src/gltf/properties/AccessorData.cpp
@@ -15,15 +15,34 @@ AccessorData::AccessorData(const BufferViewData& bufferView, GLType type, std::s
       type(std::move(type)),
       byteOffset(0),
       count(0),
-      name(name) {}
+      name(name),
+      sparse(false) {}
+
+AccessorData::AccessorData(const AccessorData& baseAccessor,
+               const BufferViewData& sparseIdxBufferView,
+               const BufferViewData& sparseDataBufferView,
+               GLType type, std::string name)
+    : Holdable(),
+      bufferView(baseAccessor.bufferView),
+      type(std::move(type)),
+      byteOffset(baseAccessor.byteOffset),
+      count(baseAccessor.count),
+      name(name),
+      sparse(true),
+      sparseIdxCount(sparseIdxBufferView.count),
+      sparseIdxBufferView(sparseIdxBufferView.ix),
+      sparseIdxBufferViewOffset(0),
+      sparseIdxBufferViewType(0),
+      sparseDataBufferView(sparseDataBufferView.ix),
+      sparseDataBufferViewOffset(0) {}
 
 AccessorData::AccessorData(GLType type)
-    : Holdable(), bufferView(-1), type(std::move(type)), byteOffset(0), count(0) {}
+    : Holdable(), bufferView(-1), type(std::move(type)), byteOffset(0), count(0), sparse(false){}
 
 json AccessorData::serialize() const {
   json result{
       {"componentType", type.componentType.glType}, {"type", type.dataType}, {"count", count}};
-  if (bufferView >= 0) {
+  if (bufferView >= 0 && !sparse) {
     result["bufferView"] = bufferView;
     result["byteOffset"] = byteOffset;
   }
@@ -32,6 +51,17 @@ json AccessorData::serialize() const {
   }
   if (!max.empty()) {
     result["max"] = max;
+  }
+  if (sparse) {
+    json sparseData = {{"count", sparseIdxCount}};
+    sparseData["indices"] = { {"bufferView", sparseIdxBufferView},
+                              {"byteOffset", sparseIdxBufferViewOffset},
+                              {"componentType", sparseIdxBufferViewType}};
+
+    sparseData["values"]  = { {"bufferView", sparseDataBufferView},
+                              {"byteOffset", sparseDataBufferViewOffset}};
+
+    result["sparse"] = sparseData;
   }
   if (name.length() > 0) {
     result["name"] = name;

--- a/src/gltf/properties/AccessorData.hpp
+++ b/src/gltf/properties/AccessorData.hpp
@@ -11,24 +11,15 @@
 #include "gltf/Raw2Gltf.hpp"
 
 struct AccessorData : Holdable {
-  AccessorData(const BufferViewData& bufferView, GLType type, std::string name);
+  AccessorData(const BufferViewData& bufferView,
+               GLType type, std::string name);
   explicit AccessorData(GLType type);
+  AccessorData(const AccessorData& baseAccessor,
+               const BufferViewData& sparseIdxBufferView,
+               const BufferViewData& sparseDataBufferView,
+               GLType type, std::string name);
 
   json serialize() const override;
-
-  template <class T>
-  void appendAsBinaryArray(const std::vector<T>& in, std::vector<uint8_t>& out) {
-    const unsigned int stride = type.byteStride();
-    const size_t offset = out.size();
-    const size_t count = in.size();
-
-    this->count = (unsigned int)count;
-
-    out.resize(offset + count * stride);
-    for (int ii = 0; ii < count; ii++) {
-      type.write(&out[offset + ii * stride], in[ii]);
-    }
-  }
 
   unsigned int byteLength() const {
     return type.byteStride() * count;
@@ -42,4 +33,12 @@ struct AccessorData : Holdable {
   std::vector<float> min;
   std::vector<float> max;
   std::string name;
+
+  const bool sparse;
+  int sparseIdxCount;
+  int sparseIdxBufferView;
+  int sparseIdxBufferViewOffset;
+  int sparseIdxBufferViewType;
+  int sparseDataBufferView;
+  int sparseDataBufferViewOffset;
 };

--- a/src/gltf/properties/BufferViewData.hpp
+++ b/src/gltf/properties/BufferViewData.hpp
@@ -21,9 +21,25 @@ struct BufferViewData : Holdable {
 
   json serialize() const override;
 
+  template <class T>
+  void appendAsBinaryArray(const std::vector<T>& in, std::vector<uint8_t>& out, GLType type) {
+    const unsigned int stride = type.byteStride();
+    const size_t offset = out.size();
+    const size_t count = in.size();
+
+    this->byteLength = stride * count;
+    this->count = count;
+
+    out.resize(offset + count * stride);
+    for (int ii = 0; ii < count; ii++) {
+      type.write(&out[offset + ii * stride], in[ii]);
+    }
+  }
+
   const unsigned int buffer;
   const unsigned int byteOffset;
   const GL_ArrayType target;
 
+  unsigned int count=0;
   unsigned int byteLength = 0;
 };

--- a/src/gltf/properties/MeshData.cpp
+++ b/src/gltf/properties/MeshData.cpp
@@ -17,7 +17,7 @@ json MeshData::serialize() const {
   json jsonTargetNamesArray = json::array();
   for (const auto& primitive : primitives) {
     jsonPrimitivesArray.push_back(*primitive);
-    if (!primitive->targetNames.empty()) {
+    if (!primitive->targetNames.empty() && jsonTargetNamesArray.empty()) {
       for (auto targetName : primitive->targetNames) {
         jsonTargetNamesArray.push_back(targetName);
       }


### PR DESCRIPTION
Blendshapes are one of those things where sparse accessors are incredibly useful, so this is a first pass at getting them working with FBX2glTF - it seems to work, glTF-validator seems completely happy with the file, but it appears that most software out there doesn't want to load them. 

Blender doesn't like having an accessor with no bufferview (adding the base position bufferview to the accessor works, but does very strange things in Blender on account of not being a giant list of zeroes).

Although position, normal and tangents could all have their own sparse indices, it made more sense to use a shared index list based on the assumption that there would be significant overlap between each index list.

I'm not super happy with the giant initializer list in the overloaded Accessor constructor, so I wouldn't mind going back and changing that and I'm not 100% convinced that normals & tangents are stored as zero length normals for non deforming vertices.

Extending these to skin weights hopefully shouldn't be a big deal, I've tried to make the new methods as flexible as possible.