### PR TITLE
Support MacOS build on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,58 +1,110 @@
 # version format
 version: 1.0.{build}
 
-environment:
+image:
+  - Visual Studio 2017
+  - MacOS
+
+for:
+-
   matrix:
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      PYTHON: "C:\\Python36-x64"
-  FBXSDK_SDKS: sdk
+    only:
+      - image: Visual Studio 2017
+  
+  environment:
+    PYTHON: "C:\\Python36-x64"
+    FBXSDK_SDKS: sdk
 
-stack: python %PYTHON%
+  stack: python %PYTHON%
 
-#temporarily disabled
-#cache:
-#  - C:\Users\appveyor\.conan\data -> appveyor.yml, conanfile.py
+  #temporarily disabled
+  #cache:
+  #  - C:\Users\appveyor\.conan\data -> appveyor.yml, conanfile.py
 
-init:
-  - git config --global filter.lfs.required false
-  - git config --global filter.lfs.smudge "git-lfs smudge --skip %f"
-  - git config --global filter.lfs.process "git-lfs filter-process --skip"
+  init:
+    - git config --global filter.lfs.required false
+    - git config --global filter.lfs.smudge "git-lfs smudge --skip %f"
+    - git config --global filter.lfs.process "git-lfs filter-process --skip"
 
-install:
-  - cinst zstandard
-  - ps: Start-FileDownload 'https://github.com/zellski/FBXSDK-Windows/archive/2019.2.tar.gz'
-  - 7z e 2019.2.tar.gz
-  - 7z x 2019.2.tar
-  - ps: move -v .\FBXSDK-Windows-2019.2\sdk\ .
-  - ps: zstd -d -r --rm sdk
-  - cmd: echo "Downloading conan..."
-  - cmd: set PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
-  - cmd: python --version
-  - cmd: python -m pip install --upgrade pip
-  - cmd: pip install conan
-  - cmd: conan user # Create the conan data directory
-  - cmd: conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan
-  - cmd: conan --version
+  install:
+    - cinst zstandard
+    - ps: Start-FileDownload 'https://github.com/zellski/FBXSDK-Windows/archive/2019.2.tar.gz'
+    - 7z e 2019.2.tar.gz
+    - 7z x 2019.2.tar
+    - ps: move -v .\FBXSDK-Windows-2019.2\sdk\ .
+    - ps: zstd -d -r --rm sdk
+    - cmd: echo "Downloading conan..."
+    - cmd: set PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
+    - cmd: python --version
+    - cmd: python -m pip install --upgrade pip
+    - cmd: pip install conan
+    - cmd: conan user # Create the conan data directory
+    - cmd: conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan
+    - cmd: conan --version
+  
+  build_script:
+    - cmd: conan install . -i build -s build_type=Release -s compiler="Visual Studio" -s compiler.version=15
+    - cmd: conan build -bf build .
+    - cmd: move build\Release\FBX2glTF.exe build\Release\FBX2glTF-windows-x64.exe
 
-build_script:
-  - cmd: conan install . -i build -s build_type=Release -s compiler="Visual Studio" -s compiler.version=15
-  - cmd: conan build -bf build .
-  - cmd: move build\Release\FBX2glTF.exe build\Release\FBX2glTF-windows-x64.exe
+  test: off
 
-test: off
+  artifacts:
+    - path: build/Release/FBX2glTF-windows-x64.exe
 
-artifacts:
-  - path: build/Release/FBX2glTF-windows-x64.exe
+  deploy:
+    tag: $(APPVEYOR_REPO_TAG_NAME)
+    description: ''
+    provider: GitHub
+    auth_token:
+      secure: OSvhQP0O9uaH+OFOJpbGiiBMRTOJ+H/VJHqVBhq39RNDnOfUEr/yjJNKh3JSdNqj
+    artifact: build/Release/FBX2glTF-windows-x64.exe
+    draft: true
+    prerelease: true
+    on:
+      branch: master
+      APPVEYOR_REPO_TAG: true
 
-deploy:
-  tag: $(APPVEYOR_REPO_TAG_NAME)
-  description: ''
-  provider: GitHub
-  auth_token:
-    secure: OSvhQP0O9uaH+OFOJpbGiiBMRTOJ+H/VJHqVBhq39RNDnOfUEr/yjJNKh3JSdNqj
-  artifact: build/Release/FBX2glTF-windows-x64.exe
-  draft: true
-  prerelease: true
-  on:
-    branch: master
-    APPVEYOR_REPO_TAG: true
+-
+  matrix:
+    only:
+      - image: macOS
+  
+  install:
+  - export HOMEBREW_NO_AUTO_UPDATE=true # Disable homebrew auto-update
+  # -------------------------------------------------------------------
+  # We can directly install conan from brew instead of pip
+  # - export PATH="/usr/local/opt/python/libexec/bin:$PATH"
+  # - brew install python # Note: python has been installed in appveyor
+  # - pip --version
+  # - pip install conan
+  # -------------------------------------------------------------------
+  - brew install zstd conan
+  - conan --version
+  - curl -sL "https://github.com/zellski/FBXSDK-Darwin/archive/2019.2.tar.gz" | tar xz --strip-components=1 */sdk
+  - zstd -d -r --rm sdk
+  - conan user
+  - conan remote add --force bincrafters https://api.bintray.com/conan/bincrafters/public-conan
+
+  build_script:
+  - conan install . -i build -s build_type=Release -s compiler=apple-clang -s compiler.version=10.0 -s compiler.libcxx=libc++
+  - conan build . -bf build
+  - mv build/FBX2glTF build/FBX2glTF-darwin-x64
+
+  test: off
+
+  artifacts:
+    - path: build/FBX2glTF-darwin-x64
+
+  deploy:
+    tag: $(APPVEYOR_REPO_TAG_NAME)
+    description: ''
+    provider: GitHub
+    auth_token:
+      secure: OSvhQP0O9uaH+OFOJpbGiiBMRTOJ+H/VJHqVBhq39RNDnOfUEr/yjJNKh3JSdNqj
+    artifact: build/FBX2glTF-darwin-x64
+    draft: true
+    prerelease: true
+    on:
+      branch: master
+      APPVEYOR_REPO_TAG: true


### PR DESCRIPTION
This PR provides the ability to build FBX2glTF for MacOS on Appveyor.

I have been tested on my fork, see https://ci.appveyor.com/project/shrinktofit/fbx2gltf-7w6ud/builds/29198685