### PR TITLE
Fixed morph target names

### DIFF
--- a/src/gltf/properties/MeshData.cpp
+++ b/src/gltf/properties/MeshData.cpp
@@ -17,7 +17,7 @@ json MeshData::serialize() const {
   json jsonTargetNamesArray = json::array();
   for (const auto& primitive : primitives) {
     jsonPrimitivesArray.push_back(*primitive);
-    if (!primitive->targetNames.empty()) {
+    if (!primitive->targetNames.empty() && jsonTargetNamesArray.empty()) {
       for (auto targetName : primitive->targetNames) {
         jsonTargetNamesArray.push_back(targetName);
       }


### PR DESCRIPTION
As mentioned in the implementation note for morph targets here: https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#morph-targets

> The targetNames array and all primitive targets arrays must have the same length.

Currently the same target names are added multiple times when present on multiple mesh primitives. This causes the length of the target names to be a multiple of the length of the primitive target arrays.