### PR TITLE
Support GLTFs via conversion with ImageMagick

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ npm/fbx2gltf/node_modules/
 npm/tests/node_modules/
 npm/tests/test/*.js
 npm/tests/test/*.js.map
+build
+sdk

--- a/src/FBX2glTF.cpp
+++ b/src/FBX2glTF.cpp
@@ -326,7 +326,7 @@ int main(int argc, char* argv[]) {
   if (verboseOutput) {
     fmt::printf("Loading FBX File: %s\n", inputPath);
   }
-  if (!LoadFBXFile(raw, inputPath, {"png", "jpg", "jpeg"}, gltfOptions)) {
+  if (!LoadFBXFile(raw, inputPath, {"png", "jpg", "jpeg", "tga"}, gltfOptions)) {
     fmt::fprintf(stderr, "ERROR:: Failed to parse FBX: %s\n", inputPath);
     return 1;
   }

--- a/src/fbx/Fbx2Raw.cpp
+++ b/src/fbx/Fbx2Raw.cpp
@@ -32,6 +32,14 @@
 #include "materials/RoughnessMetallicMaterials.hpp"
 #include "materials/TraditionalMaterials.hpp"
 
+#ifdef _WIN32
+#define SLASH_CHAR '\\'
+#define ALTERNATIVE_SLASH_CHAR '/'
+#else
+#define SLASH_CHAR '/'
+#define ALTERNATIVE_SLASH_CHAR '\\'
+#endif
+
 float scaleFactor;
 
 static std::string NativeToUTF8(const std::string& str) {
@@ -1028,6 +1036,16 @@ static std::string FindFbxTexture(
   // else look in other designated folders
   for (int ii = 0; ii < folders.size(); ii++) {
     const auto& fileLocation = FindFileLoosely(textureFileName, folders[ii], folderContents[ii]);
+    if (!fileLocation.empty()) {
+      return FileUtils::GetAbsolutePath(fileLocation);
+    }
+  }
+  //Replace slashes with alternative platform version (e.g. '/' instead of '\\')
+  std::string textureFileNameAltSlash = textureFileName;
+  std::replace( textureFileNameAltSlash.begin(), textureFileNameAltSlash.end(), ALTERNATIVE_SLASH_CHAR, SLASH_CHAR);
+  // finally look with alternative slashes
+  for (int ii = 0; ii < folders.size(); ii++) {
+    const auto& fileLocation = FindFileLoosely(textureFileNameAltSlash, folders[ii], folderContents[ii]);
     if (!fileLocation.empty()) {
       return FileUtils::GetAbsolutePath(fileLocation);
     }


### PR DESCRIPTION
TGAs are supported in FBX but not GLTF.  This PR uses ImageMagick command line to convert TGAs to PNG and then adds them to the GLTF.

(This PR has files from my previous slash conversion PR, will retarget when that is pushed)