### PR TITLE
Added sparse blendshape support

### DIFF
--- a/src/FBX2glTF.cpp
+++ b/src/FBX2glTF.cpp
@@ -143,6 +143,11 @@ int main(int argc, char* argv[]) {
       "Transcribe FBX User Properties into glTF node and material 'extras'.");
 
   app.add_flag(
+      "--blend-shape-sparse",
+      gltfOptions.enableSparseBlendShapes,
+      "Use sparse accessors to store blend shapes");
+
+  app.add_flag(
       "--blend-shape-normals",
       gltfOptions.useBlendShapeNormals,
       "Include blend shape normals, if reported present by the FBX SDK.");

--- a/src/FBX2glTF.h
+++ b/src/FBX2glTF.h
@@ -112,6 +112,8 @@ struct GltfOptions {
   /** Whether to include lights through the KHR_punctual_lights extension. */
   bool useKHRLightsPunctual{true};
 
+  /** Whether to use sparse accessors in blend shapes */
+  bool enableSparseBlendShapes{false};
   /** Whether to include blend shape normals, if present according to the SDK. */
   bool useBlendShapeNormals{false};
   /** Whether to include blend shape tangents, if present according to the SDK. */

--- a/src/gltf/GltfModel.hpp
+++ b/src/gltf/GltfModel.hpp
@@ -70,14 +70,38 @@ class GltfModel {
       const std::string& filename);
 
   template <class T>
+  void CopyToBufferView(
+      BufferViewData& bufferView,
+      const std::vector<T>& source,
+      const GLType& type) {
+        bufferView.appendAsBinaryArray(source, *binary, type);
+      }
+
+  template <class T>
   std::shared_ptr<AccessorData> AddAccessorWithView(
       BufferViewData& bufferView,
       const GLType& type,
       const std::vector<T>& source,
       std::string name) {
     auto accessor = accessors.hold(new AccessorData(bufferView, type, name));
-    accessor->appendAsBinaryArray(source, *binary);
-    bufferView.byteLength = accessor->byteLength();
+    bufferView.appendAsBinaryArray(source, *binary, type);
+    accessor->count = bufferView.count;
+    return accessor;
+  }
+
+  template <class T>
+  std::shared_ptr<AccessorData> AddSparseAccessorWithView(
+      AccessorData& baseAccessor,
+      BufferViewData& indexBufferView,
+      const GLType& indexBufferViewType,
+      BufferViewData& bufferView,
+      const GLType& type,
+      const std::vector<T>& source,
+      std::string name) {
+    auto accessor = accessors.hold(new AccessorData(baseAccessor, indexBufferView, bufferView, type, name));
+    bufferView.appendAsBinaryArray(source, *binary, type);
+    accessor->count = baseAccessor.count;
+    accessor->sparseIdxBufferViewType = indexBufferViewType.componentType.glType;
     return accessor;
   }
 

--- a/src/gltf/GltfModel.hpp
+++ b/src/gltf/GltfModel.hpp
@@ -105,6 +105,22 @@ class GltfModel {
     return accessor;
   }
 
+//  template <class T>
+  std::shared_ptr<AccessorData> AddSparseAccessor(
+      AccessorData& baseAccessor,
+      BufferViewData& indexBufferView,
+      const GLType& indexBufferViewType,
+      BufferViewData& bufferView,
+      const GLType& type,
+//      const std::vector<T>& source,
+      std::string name) {
+    auto accessor = accessors.hold(new AccessorData(baseAccessor, indexBufferView, bufferView, type, name));
+    //bufferView.appendAsBinaryArray(source, *binary, type);
+    accessor->count = baseAccessor.count;
+    accessor->sparseIdxBufferViewType = indexBufferViewType.componentType.glType;
+    return accessor;
+  }
+
   template <class T>
   std::shared_ptr<AccessorData>
   AddAccessorAndView(BufferData& buffer, const GLType& type, const std::vector<T>& source) {

--- a/src/gltf/properties/AccessorData.cpp
+++ b/src/gltf/properties/AccessorData.cpp
@@ -15,15 +15,34 @@ AccessorData::AccessorData(const BufferViewData& bufferView, GLType type, std::s
       type(std::move(type)),
       byteOffset(0),
       count(0),
-      name(name) {}
+      name(name),
+      sparse(false) {}
+
+AccessorData::AccessorData(const AccessorData& baseAccessor,
+               const BufferViewData& sparseIdxBufferView,
+               const BufferViewData& sparseDataBufferView,
+               GLType type, std::string name)
+    : Holdable(),
+      bufferView(baseAccessor.bufferView),
+      type(std::move(type)),
+      byteOffset(baseAccessor.byteOffset),
+      count(baseAccessor.count),
+      name(name),
+      sparse(true),
+      sparseIdxCount(sparseIdxBufferView.count),
+      sparseIdxBufferView(sparseIdxBufferView.ix),
+      sparseIdxBufferViewOffset(0),
+      sparseIdxBufferViewType(0),
+      sparseDataBufferView(sparseDataBufferView.ix),
+      sparseDataBufferViewOffset(0) {}
 
 AccessorData::AccessorData(GLType type)
-    : Holdable(), bufferView(-1), type(std::move(type)), byteOffset(0), count(0) {}
+    : Holdable(), bufferView(-1), type(std::move(type)), byteOffset(0), count(0), sparse(false){}
 
 json AccessorData::serialize() const {
   json result{
       {"componentType", type.componentType.glType}, {"type", type.dataType}, {"count", count}};
-  if (bufferView >= 0) {
+  if (bufferView >= 0 && !sparse) {
     result["bufferView"] = bufferView;
     result["byteOffset"] = byteOffset;
   }
@@ -32,6 +51,17 @@ json AccessorData::serialize() const {
   }
   if (!max.empty()) {
     result["max"] = max;
+  }
+  if (sparse) {
+    json sparseData = {{"count", sparseIdxCount}};
+    sparseData["indices"] = { {"bufferView", sparseIdxBufferView},
+                              {"byteOffset", sparseIdxBufferViewOffset},
+                              {"componentType", sparseIdxBufferViewType}};
+
+    sparseData["values"]  = { {"bufferView", sparseDataBufferView},
+                              {"byteOffset", sparseDataBufferViewOffset}};
+
+    result["sparse"] = sparseData;
   }
   if (name.length() > 0) {
     result["name"] = name;

--- a/src/gltf/properties/AccessorData.hpp
+++ b/src/gltf/properties/AccessorData.hpp
@@ -11,24 +11,15 @@
 #include "gltf/Raw2Gltf.hpp"
 
 struct AccessorData : Holdable {
-  AccessorData(const BufferViewData& bufferView, GLType type, std::string name);
+  AccessorData(const BufferViewData& bufferView,
+               GLType type, std::string name);
   explicit AccessorData(GLType type);
+  AccessorData(const AccessorData& baseAccessor,
+               const BufferViewData& sparseIdxBufferView,
+               const BufferViewData& sparseDataBufferView,
+               GLType type, std::string name);
 
   json serialize() const override;
-
-  template <class T>
-  void appendAsBinaryArray(const std::vector<T>& in, std::vector<uint8_t>& out) {
-    const unsigned int stride = type.byteStride();
-    const size_t offset = out.size();
-    const size_t count = in.size();
-
-    this->count = (unsigned int)count;
-
-    out.resize(offset + count * stride);
-    for (int ii = 0; ii < count; ii++) {
-      type.write(&out[offset + ii * stride], in[ii]);
-    }
-  }
 
   unsigned int byteLength() const {
     return type.byteStride() * count;
@@ -42,4 +33,12 @@ struct AccessorData : Holdable {
   std::vector<float> min;
   std::vector<float> max;
   std::string name;
+
+  const bool sparse;
+  int sparseIdxCount;
+  int sparseIdxBufferView;
+  int sparseIdxBufferViewOffset;
+  int sparseIdxBufferViewType;
+  int sparseDataBufferView;
+  int sparseDataBufferViewOffset;
 };

--- a/src/gltf/properties/BufferViewData.hpp
+++ b/src/gltf/properties/BufferViewData.hpp
@@ -21,9 +21,25 @@ struct BufferViewData : Holdable {
 
   json serialize() const override;
 
+  template <class T>
+  void appendAsBinaryArray(const std::vector<T>& in, std::vector<uint8_t>& out, GLType type) {
+    const unsigned int stride = type.byteStride();
+    const size_t offset = out.size();
+    const size_t count = in.size();
+
+    this->byteLength = stride * count;
+    this->count = count;
+
+    out.resize(offset + count * stride);
+    for (int ii = 0; ii < count; ii++) {
+      type.write(&out[offset + ii * stride], in[ii]);
+    }
+  }
+
   const unsigned int buffer;
   const unsigned int byteOffset;
   const GL_ArrayType target;
 
+  unsigned int count=0;
   unsigned int byteLength = 0;
 };

--- a/src/gltf/properties/MeshData.cpp
+++ b/src/gltf/properties/MeshData.cpp
@@ -17,7 +17,7 @@ json MeshData::serialize() const {
   json jsonTargetNamesArray = json::array();
   for (const auto& primitive : primitives) {
     jsonPrimitivesArray.push_back(*primitive);
-    if (!primitive->targetNames.empty()) {
+    if (!primitive->targetNames.empty() && jsonTargetNamesArray.empty()) {
       for (auto targetName : primitive->targetNames) {
         jsonTargetNamesArray.push_back(targetName);
       }


### PR DESCRIPTION
Using the --blend-shape-sparse flag, FBX2glTF now correctly computes sparse arrays for blendshape storage, which seems to reduce the output file size by anywhere from 60-90%, particularly with large numbers of minimally different blendshapes.

gltf_validator seems perfectly happy with the sparse files and they load into various viewers fine.

Meshes with multiple primitives can generate empty accessors, however, such as when the blendshape is applied to one of the other primitives in the mesh, in this case a single element dummy bufferview gets used, since an accessor's sparse count has to be greater than 0 and the number of accessors has to match the number of morph targets.

Without the --blend-shape-sparse flag, FBX2glTF should operate exactly as before, he said, optimistically.

Also fixed the duplication of target names in the mesh.extras.targetNames array.