### PR TITLE
Fixed Dockerfile build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 
 RUN apt-get update && \
     apt-get install -y software-properties-common && \
-    add-apt-repository ppa:jonathonf/python-3.6 && \
+    add-apt-repository ppa:deadsnakes/ppa && \
     add-apt-repository ppa:git-core/ppa && \
     apt-get update && \
     apt-get install -y python3.6 curl build-essential cmake libxml2-dev zlib1g-dev git && \


### PR DESCRIPTION
The repository jonathonf/python-3.6 is no longer public and that provoque that the docker build image fails.

Modified the repository with another one that it's public.